### PR TITLE
Autotoolization: manpages: revisit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 
 lib_LTLIBRARIES = libprimesieve.la
 libprimesieve_la_CXXFLAGS = $(OPENMP_CXXFLAGS)
-libprimesieve_la_LDFLAGS = -version-info @primesieve_lib_version@
+libprimesieve_la_LDFLAGS = -version-info $(primesieve_lib_version)
 
 if FORCE_SHARED_LIBRARY
 libprimesieve_la_LDFLAGS += -no-undefined 
@@ -45,7 +45,7 @@ DISTCLEANFILES = \
 	doc/Doxyfile
 
 man_MANS = \
-	doc/primesieve.1
+	primesieve.1
 
 libprimesieve_la_SOURCES = \
 	src/primesieve/EratBig.cpp \
@@ -161,16 +161,25 @@ doxygen:
 	cd doc && $(DOXYGEN)
 endif
 
+if MAINTAINER_MODE
 if HAVE_HELP2MAN
-help2man: doc/primesieve.1
 
-doc/primesieve.1: primesieve
-	$(HELP2MAN) --manual="primesieve" \
-         --source="primesieve @PACKAGE_VERSION@" \
-         -n "efficient prime number generator" \
-         -s 1 --no-info \
-         -o doc/primesieve.1 primesieve
+H2MFLAGS = \
+	--manual="primesieve" \
+	--source="primesieve $(PACKAGE_VERSION)" \
+	--locale=C.UTF-8 \
+	--libtool \
+	--no-info
+
+primesieve.1: primesieve
+	$(HELP2MAN) \
+			-s 1 \
+			$(H2MFLAGS) \
+			-n "efficient prime number generator" \
+			-o $@ \
+		./$<
+
+endif
 endif
 
-man: $(HELP2MAN)
-doc: man $(DOXYGEN)
+doc: $(DOXYGEN)

--- a/configure.ac
+++ b/configure.ac
@@ -19,8 +19,11 @@ LT_INIT
 
 # doxygen is used to generate C/C++ API documentation
 AC_CHECK_PROG([DOXYGEN], [doxygen], [doxygen])
-
 AM_CONDITIONAL([HAVE_DOXYGEN], [test x$DOXYGEN = xdoxygen])
+
+# help2man is used to generate manpages (maintainer mode)
+AC_CHECK_PROG([HELP2MAN], [help2man], [help2man])
+AM_CONDITIONAL([HAVE_HELP2MAN], [test x$HELP2MAN = xhelp2man])
 
 # Check if graphviz is installed
 AC_CHECK_PROG([HAVE_DOT], [dot], [YES], [NO])
@@ -29,12 +32,6 @@ AC_ARG_WITH([help2man],
     [AS_HELP_STRING([--with-help2man], [Use help2man to generate man pages])],
     WITH_HELP2MAN="yes")
 
-AS_IF([test "x$WITH_HELP2MAN" = "xyes"], [
-    AC_CHECK_PROG([HELP2MAN], [help2man], [help2man])
-    test -z "$HELP2MAN" && AC_MSG_ERROR([help2man not found])
-])
-
-AM_CONDITIONAL([HAVE_HELP2MAN], [test x$HELP2MAN = xhelp2man])
 
 AC_ARG_ENABLE(examples,
     [AS_HELP_STRING([--enable-examples], [Compile the examples programs])],

--- a/doc/README.md
+++ b/doc/README.md
@@ -7,7 +7,7 @@ documentation you need to have installed the ```help2man``` and
 directory.
 
 ```bash
-$ ./configure --with-help2man
+$ ./configure --enable-maintainer-mode
 $ make man
 $ make doxygen
 ```


### PR DESCRIPTION
Description: autotoolization: manpages
 Attempt to render the autotools machinery to generate the manpage
 more conform to what is expected by packagers.
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2016-11-15
