### PR TITLE
Allow architecture independent installation for headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,8 @@ endif()
 # Install headers ####################################################
 
 install(FILES include/primesieve.h
-              include/primesieve.hpp        
+              include/primesieve.hpp
+              COMPONENT libprimesieve-headers
               DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 
 install(FILES include/primesieve/PrimeSieve.hpp
@@ -114,6 +115,7 @@ install(FILES include/primesieve/PrimeSieve.hpp
               include/primesieve/iterator.hpp
               include/primesieve/primesieve_error.hpp
               include/primesieve/pmath.hpp
+              COMPONENT libprimesieve-headers
               DESTINATION ${CMAKE_INSTALL_PREFIX}/include/primesieve)
 
 # Regenerate man page ################################################


### PR DESCRIPTION
Description: upstream: cmake machinery: libheaders COMPONENT
 Add COMPONENT key to headers installation in order to allow
 architecture independent installation; meant to simplify
 distribution maintenance.
Origin: vendor, Debian
Comment: enhancement
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2017-11-11