### PR TITLE
Add library multiarch support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 install(TARGETS libprimesieve
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_LIBRARY_MULTIARCH})
 
 # static_libprimesieve ###############################################
 
@@ -90,7 +90,7 @@ if(BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS)
         $<INSTALL_INTERFACE:include>)
 
     install(TARGETS static_libprimesieve
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_LIBRARY_MULTIARCH})
 endif()
 
 # primesieve binary ##################################################
@@ -160,7 +160,7 @@ endif()
 configure_file(primesieve.pc.in primesieve.pc @ONLY)
 
 install(FILES ${CMAKE_BINARY_DIR}/primesieve.pc
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_LIBRARY_MULTIARCH}/pkgconfig)
 
 # Add subdirectories #################################################
 


### PR DESCRIPTION
Description: upstream: cmake machinery: library multiarch support
 Attempt to add library multiarch support; meant to simplify
 distribution maintenance.
Origin: vendor, Debian
Comment: enhancement
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2017-11-11