### PR TITLE
Fix undefined reference to `__atomic_fetch_add_8'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,12 +57,21 @@ if(no_fallthrough)
     set_source_files_properties(src/primesieve/EratSmall.cpp PROPERTIES COMPILE_FLAGS -Wno-implicit-fallthrough)
 endif()
 
+# Find optional atomic library #######################################
+
+find_library(ATOMIC atomic)
+
+if(ATOMIC)
+    set(LIBATOMIC ${ATOMIC})
+    message(STATUS "Found libatomic: TRUE")
+endif()
+
 # libprimesieve ######################################################
 
 add_library(libprimesieve ${LIB_SRC})
 set_target_properties(libprimesieve PROPERTIES OUTPUT_NAME primesieve)
 find_package(Threads REQUIRED)
-target_link_libraries(libprimesieve Threads::Threads)
+target_link_libraries(libprimesieve Threads::Threads ${LIBATOMIC})
 
 target_include_directories(libprimesieve PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -83,7 +92,7 @@ install(TARGETS libprimesieve
 if(BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS)
     add_library(static_libprimesieve STATIC ${LIB_SRC})
     set_target_properties(static_libprimesieve PROPERTIES OUTPUT_NAME primesieve)
-    target_link_libraries(static_libprimesieve Threads::Threads)
+    target_link_libraries(static_libprimesieve Threads::Threads ${LIBATOMIC})
 
     target_include_directories(static_libprimesieve PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ endif()
 
 include(CheckCXXSourceCompiles)
 
-set(CMAKE_OLD_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS})
-set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_CXX11_STANDARD_COMPILE_OPTION})
+set(CMAKE_OLD_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_FLAGS ${CMAKE_CXX11_STANDARD_COMPILE_OPTION})
 
 check_cxx_source_compiles("
     #include <atomic>
@@ -74,7 +74,7 @@ check_cxx_source_compiles("
     }"
     have_atomic)
 
-set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_OLD_DEFINITIONS})
+set(CMAKE_REQUIRED_FLAGS ${CMAKE_OLD_FLAGS})
 
 if(NOT have_atomic)
     find_library(ATOMIC NAMES atomic libatomic.so libatomic.so.1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ endif()
 
 include(CheckCXXSourceCompiles)
 
+set(CMAKE_OLD_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS})
+set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_CXX11_STANDARD_COMPILE_OPTION})
+
 check_cxx_source_compiles("
     #include <atomic>
     int main() {
@@ -71,8 +74,10 @@ check_cxx_source_compiles("
     }"
     HAVE_ATOMIC)
 
-if(not HAVE_ATOMIC)
-    find_library(ATOMIC NAMES atomic libatomic.so.1)
+set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_OLD_DEFINITIONS})
+
+if(NOT HAVE_ATOMIC)
+    find_library(ATOMIC NAMES atomic libatomic.so libatomic.so.1)
     if(ATOMIC)
         set(LIBATOMIC ${ATOMIC})
         message(STATUS "Found libatomic: TRUE")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,26 @@ if(no_fallthrough)
     set_source_files_properties(src/primesieve/EratSmall.cpp PROPERTIES COMPILE_FLAGS -Wno-implicit-fallthrough)
 endif()
 
-# Find optional atomic library #######################################
+# Check if libatomic is needed #######################################
 
-find_library(ATOMIC atomic)
+include(CheckCXXSourceCompiles)
 
-if(ATOMIC)
-    set(LIBATOMIC ${ATOMIC})
-    message(STATUS "Found libatomic: TRUE")
+check_cxx_source_compiles("
+    #include <atomic>
+    int main() {
+        std::atomic<int> x;
+        x = 1;
+        x--;
+        return x;
+    }"
+    HAVE_ATOMIC)
+
+if(not HAVE_ATOMIC)
+    find_library(ATOMIC NAMES atomic libatomic.so.1)
+    if(ATOMIC)
+        set(LIBATOMIC ${ATOMIC})
+        message(STATUS "Found libatomic: TRUE")
+    endif()
 endif()
 
 # libprimesieve ######################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,11 +72,11 @@ check_cxx_source_compiles("
         x--;
         return x;
     }"
-    HAVE_ATOMIC)
+    have_atomic)
 
 set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_OLD_DEFINITIONS})
 
-if(NOT HAVE_ATOMIC)
+if(NOT have_atomic)
     find_library(ATOMIC NAMES atomic libatomic.so libatomic.so.1)
     if(ATOMIC)
         set(LIBATOMIC ${ATOMIC})

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+Changes in version 6.3, 12/11/2017
+==================================
+
+This is a minor new release, the API and ABI are
+backwards compatible.
+
+ * test/ilog2.cpp: Fix Linux i386 bug.
+ * test/floorPower2.cpp: Fix Linux i386 bug.
+ * CMakeLists.txt: Link against libatomic if needed.
+ * CMakeLists.txt: Add Debian Multiarch support.
+
 Changes in version 6.2, 12/10/2017
 ==================================
 


### PR DESCRIPTION
```bash
libprimesieve.so.8.2.0: undefined reference to `__atomic_fetch_add_8'
```

This pull request should fix the linker error above which occurred on some rarely used Debian architectures e.g.  armel, mips, powerpc, ... See https://github.com/kimwalisch/primesieve/issues/45 for more information.

The problem is that on some Linux architectures the C++11 atomic support is not yet properly supported and therefore one has to link against ```libatomic```on these architectures.