### PR TITLE
Fedora packaging workaround for static libprimesieve

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BUILD_SHARED_LIBS)
         $<INSTALL_INTERFACE:include>)
 
     install(TARGETS libprimesieve
-            EXPORT primesieveTargets
+            EXPORT primesieveShared
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -177,7 +177,7 @@ if(BUILD_STATIC_LIBS)
         $<INSTALL_INTERFACE:include>)
 
     install(TARGETS libprimesieve-static
-            EXPORT primesieveTargets
+            EXPORT primesieveStatic
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -228,9 +228,17 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/primesieveConfig.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/primesieveConfigVersion.cmake"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/primesieve")
 
-install(EXPORT primesieveTargets
-        NAMESPACE primesieve::
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/primesieve")
+if(BUILD_SHARED_LIBS)
+    install(EXPORT primesieveShared
+            NAMESPACE primesieve::
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/primesieve")
+endif()
+
+if(BUILD_STATIC_LIBS)
+    install(EXPORT primesieveStatic
+            NAMESPACE primesieve::
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/primesieve")
+endif()
 
 # Regenerate man page ################################################
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,11 @@ Since primesieve-6.4 you can easily link against libprimesieve in your
 ```CMake
 find_package(primesieve REQUIRED)
 target_link_libraries(your_target primesieve::primesieve)
+```
 
-# To link against the static libprimesieve use:
+To link against the static libprimesieve use:
+
+```CMake
 find_package(primesieve REQUIRED static)
 target_link_libraries(your_target primesieve::primesieve)
 ```

--- a/README.md
+++ b/README.md
@@ -181,10 +181,11 @@ Since primesieve-6.4 you can easily link against libprimesieve in your
 
 ```CMake
 find_package(primesieve REQUIRED)
-target_link_libraries(your_target primesieve::libprimesieve)
+target_link_libraries(your_target primesieve::primesieve)
 
-# Or link against the static libprimesieve
-target_link_libraries(your_target primesieve::libprimesieve-static)
+# To link against the static libprimesieve use:
+find_package(primesieve REQUIRED static)
+target_link_libraries(your_target primesieve::primesieve)
 ```
 
 ## Bindings for other languages

--- a/cmake/primesieveConfig.cmake.in
+++ b/cmake/primesieveConfig.cmake.in
@@ -22,3 +22,8 @@ foreach(FILENAME "primesieveShared.cmake" "primesieveStatic.cmake")
         include("${CMAKE_CURRENT_LIST_DIR}/${FILENAME}")
     endif()
 endforeach()
+
+if(NOT @BUILD_SHARED_LIBS@)
+    add_library(primesieve::libprimesieve INTERFACE IMPORTED)
+    set_target_properties(primesieve::libprimesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve-static")
+endif()

--- a/cmake/primesieveConfig.cmake.in
+++ b/cmake/primesieveConfig.cmake.in
@@ -1,9 +1,48 @@
+# ====================================================================
+# The primesieve CMake configuration file
+#
+# Usage from an external project:
+#     In your CMakeLists.txt, add these lines:
+#
+#     find_package(primesieve REQUIRED)
+#     target_link_libraries(your_target primesieve::primesieve)
+#
+#     To link against the static libprimesieve use:
+#
+#     find_package(primesieve REQUIRED static)
+#     target_link_libraries(your_target primesieve::primesieve)
+#
+# ====================================================================
+
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
-include("${CMAKE_CURRENT_LIST_DIR}/primesieveTargets.cmake")
 
-# Make sure primesieve::libprimesieve is always defined
-if(NOT @BUILD_SHARED_LIBS@)
-    add_library(primesieve::libprimesieve INTERFACE IMPORTED)
-    set_target_properties(primesieve::libprimesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve-static")
+if(@BUILD_SHARED_LIBS@ AND @BUILD_STATIC_LIBS@)
+
+    if(primesieve_FIND_COMPONENTS)
+        string(TOUPPER "${primesieve_FIND_COMPONENTS}" UPPER_COMPONENTS)
+        list(FIND UPPER_COMPONENTS "STATIC" FOUND_STATIC)
+        if(FOUND_STATIC GREATER -1)
+            set(USE_STATIC_LIBPRIMESIEVE "ON")
+        endif()
+    endif()
+
+    if(USE_STATIC_LIBPRIMESIEVE)
+        include("${CMAKE_CURRENT_LIST_DIR}/primesieveStatic.cmake")
+        add_library(primesieve::primesieve INTERFACE IMPORTED)
+        set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve-static")
+    else()
+        include("${CMAKE_CURRENT_LIST_DIR}/primesieveShared.cmake")
+        add_library(primesieve::primesieve INTERFACE IMPORTED)
+        set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve")
+    endif()
+
+elseif(@BUILD_STATIC_LIBS@)
+    include("${CMAKE_CURRENT_LIST_DIR}/primesieveStatic.cmake")
+    add_library(primesieve::primesieve INTERFACE IMPORTED)
+    set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve-static")
+else()
+    include("${CMAKE_CURRENT_LIST_DIR}/primesieveShared.cmake")
+    add_library(primesieve::primesieve INTERFACE IMPORTED)
+    set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve")
 endif()

--- a/cmake/primesieveConfig.cmake.in
+++ b/cmake/primesieveConfig.cmake.in
@@ -1,40 +1,24 @@
-# ====================================================================
+# ========================================================================
 # The primesieve CMake configuration file
 #
 # Usage from an external project:
 #     In your CMakeLists.txt, add these lines:
 #
 #     find_package(primesieve REQUIRED)
-#     target_link_libraries(your_target primesieve::primesieve)
+#     target_link_libraries(your_target primesieve::libprimesieve)
 #
 #     To link against the static libprimesieve use:
 #
-#     find_package(primesieve REQUIRED static)
-#     target_link_libraries(your_target primesieve::primesieve)
+#     find_package(primesieve REQUIRED)
+#     target_link_libraries(your_target primesieve::libprimesieve-static)
 #
-# ====================================================================
+# ========================================================================
 
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 
-if(@BUILD_STATIC_LIBS@ AND @BUILD_SHARED_LIBS@)
-    if(primesieve_FIND_COMPONENTS)
-        string(TOUPPER "${primesieve_FIND_COMPONENTS}" UPPER_COMPONENTS)
-        list(FIND UPPER_COMPONENTS "STATIC" FOUND_STATIC)
-        if(FOUND_STATIC GREATER -1)
-            set(USE_STATIC_LIBPRIMESIEVE "ON")
-        endif()
+foreach(FILENAME "primesieveShared.cmake" "primesieveStatic.cmake")
+    if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/${FILENAME}")
+        include("${CMAKE_CURRENT_LIST_DIR}/${FILENAME}")
     endif()
-elseif(@BUILD_STATIC_LIBS@)
-    set(USE_STATIC_LIBPRIMESIEVE "ON")
-endif()
-
-if(USE_STATIC_LIBPRIMESIEVE)
-    include("${CMAKE_CURRENT_LIST_DIR}/primesieveStatic.cmake")
-    add_library(primesieve::primesieve INTERFACE IMPORTED)
-    set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve-static")
-else()
-    include("${CMAKE_CURRENT_LIST_DIR}/primesieveShared.cmake")
-    add_library(primesieve::primesieve INTERFACE IMPORTED)
-    set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve")
-endif()
+endforeach()

--- a/cmake/primesieveConfig.cmake.in
+++ b/cmake/primesieveConfig.cmake.in
@@ -17,8 +17,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 
-if(@BUILD_SHARED_LIBS@ AND @BUILD_STATIC_LIBS@)
-
+if(@BUILD_STATIC_LIBS@ AND @BUILD_SHARED_LIBS@)
     if(primesieve_FIND_COMPONENTS)
         string(TOUPPER "${primesieve_FIND_COMPONENTS}" UPPER_COMPONENTS)
         list(FIND UPPER_COMPONENTS "STATIC" FOUND_STATIC)
@@ -26,18 +25,11 @@ if(@BUILD_SHARED_LIBS@ AND @BUILD_STATIC_LIBS@)
             set(USE_STATIC_LIBPRIMESIEVE "ON")
         endif()
     endif()
-
-    if(USE_STATIC_LIBPRIMESIEVE)
-        include("${CMAKE_CURRENT_LIST_DIR}/primesieveStatic.cmake")
-        add_library(primesieve::primesieve INTERFACE IMPORTED)
-        set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve-static")
-    else()
-        include("${CMAKE_CURRENT_LIST_DIR}/primesieveShared.cmake")
-        add_library(primesieve::primesieve INTERFACE IMPORTED)
-        set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve")
-    endif()
-
 elseif(@BUILD_STATIC_LIBS@)
+    set(USE_STATIC_LIBPRIMESIEVE "ON")
+endif()
+
+if(USE_STATIC_LIBPRIMESIEVE)
     include("${CMAKE_CURRENT_LIST_DIR}/primesieveStatic.cmake")
     add_library(primesieve::primesieve INTERFACE IMPORTED)
     set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve-static")

--- a/cmake/primesieveConfig.cmake.in
+++ b/cmake/primesieveConfig.cmake.in
@@ -1,29 +1,40 @@
-# ========================================================================
+# ====================================================================
 # The primesieve CMake configuration file
 #
 # Usage from an external project:
 #     In your CMakeLists.txt, add these lines:
 #
 #     find_package(primesieve REQUIRED)
-#     target_link_libraries(your_target primesieve::libprimesieve)
+#     target_link_libraries(your_target primesieve::primesieve)
 #
 #     To link against the static libprimesieve use:
 #
-#     find_package(primesieve REQUIRED)
-#     target_link_libraries(your_target primesieve::libprimesieve-static)
+#     find_package(primesieve REQUIRED static)
+#     target_link_libraries(your_target primesieve::primesieve)
 #
-# ========================================================================
+# ====================================================================
 
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 
-foreach(FILENAME "primesieveShared.cmake" "primesieveStatic.cmake")
-    if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/${FILENAME}")
-        include("${CMAKE_CURRENT_LIST_DIR}/${FILENAME}")
+if(@BUILD_STATIC_LIBS@ AND @BUILD_SHARED_LIBS@)
+    if(primesieve_FIND_COMPONENTS)
+        string(TOUPPER "${primesieve_FIND_COMPONENTS}" UPPER_COMPONENTS)
+        list(FIND UPPER_COMPONENTS "STATIC" FOUND_STATIC)
+        if(FOUND_STATIC GREATER -1)
+            set(USE_STATIC_LIBPRIMESIEVE "ON")
+        endif()
     endif()
-endforeach()
+elseif(@BUILD_STATIC_LIBS@)
+    set(USE_STATIC_LIBPRIMESIEVE "ON")
+endif()
 
-if(NOT @BUILD_SHARED_LIBS@)
-    add_library(primesieve::libprimesieve INTERFACE IMPORTED)
-    set_target_properties(primesieve::libprimesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve-static")
+if(USE_STATIC_LIBPRIMESIEVE)
+    include("${CMAKE_CURRENT_LIST_DIR}/primesieveStatic.cmake")
+    add_library(primesieve::primesieve INTERFACE IMPORTED)
+    set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve-static")
+else()
+    include("${CMAKE_CURRENT_LIST_DIR}/primesieveShared.cmake")
+    add_library(primesieve::primesieve INTERFACE IMPORTED)
+    set_target_properties(primesieve::primesieve PROPERTIES INTERFACE_LINK_LIBRARIES "primesieve::libprimesieve")
 endif()


### PR DESCRIPTION
Fedora requires that static libraries are put into their own package e.g. ```libprimesieve-static```.

Previously ```find_package(primesieve)``` would check that both the static and shared libprimesieve libraries exist. If one of the libraries did not exist ```find_package(primesieve)``` failed. Hence ```find_package(primesieve)``` failed on Fedora unless both the ```libprimesieve-devel``` (shared libprimesieve) and ```libprimesieve-static``` packages were installed.

This pull request fixes the issue by exporting the shared libprimesieve into ```primesieveShared.cmake``` file and the static libprimesieve into ```primesieveStatic.cmake```.