### PR TITLE
Take into consideration SMT threads when blocking for L1 cache

### DIFF
--- a/include/primesieve/CpuInfo.hpp
+++ b/include/primesieve/CpuInfo.hpp
@@ -25,10 +25,12 @@ public:
   bool privateL2Cache() const;
   std::string getError() const;
   std::size_t l1CacheSize() const;
+  std::size_t smtThreads() const;
   std::size_t l2CacheSize() const;
 
 private:
   std::size_t l1CacheSize_;
+  std::size_t smtThreads_;
   std::size_t l2CacheSize_;
   bool privateL2Cache_;
   std::string error_;

--- a/src/CpuInfo.cpp
+++ b/src/CpuInfo.cpp
@@ -93,6 +93,7 @@ namespace primesieve {
 
 CpuInfo::CpuInfo()
   : l1CacheSize_(0),
+    smtThreads_(1),
     l2CacheSize_(0),
     privateL2Cache_(false)
 {
@@ -109,6 +110,11 @@ CpuInfo::CpuInfo()
 size_t CpuInfo::l1CacheSize() const
 {
   return l1CacheSize_;
+}
+
+size_t CpuInfo::smtThreads() const
+{
+  return smtThreads_;
 }
 
 size_t CpuInfo::l2CacheSize() const
@@ -318,6 +324,18 @@ void CpuInfo::init()
          type == "Unified"))
     {
       l1CacheSize_ = getValue(cacheSize);
+      threadSiblingsList = getString(threadSiblingsList);
+      if (!threadSiblingsList.empty())
+      {
+        unsigned int first, last, threads;
+
+        if (sscanf(threadSiblingsList.c_str(), "%u-%u", &first, &last) == 2)
+        {
+          threads = last - first + 1;
+          if (threads > 0)
+            smtThreads_ = threads;
+        }
+      }
     }
 
     if (level == 2 &&

--- a/src/EratSmall.cpp
+++ b/src/EratSmall.cpp
@@ -54,7 +54,7 @@ uint64_t EratSmall::getL1Size(uint64_t sieveSize)
   if (!cpuInfo.hasL1Cache())
     return sieveSize;
 
-  uint64_t size = cpuInfo.l1CacheSize();
+  uint64_t size = cpuInfo.l1CacheSize() / cpuInfo.smtThreads();
   uint64_t minSize = 8 << 10;
   uint64_t maxSize = 4096 << 10;
 

--- a/test/cpu_info.cpp
+++ b/test/cpu_info.cpp
@@ -49,5 +49,7 @@ int main()
       cout << "L2 cache: shared"  << endl;
   }
 
+  cout << "SMT threads per core " << cpuInfo.smtThreads() << endl;
+
   return 0;
 }


### PR DESCRIPTION
SMT threads share an L1 cache, so to avoid spilling out of the
L1 cache we need to divide the cache size by the number of threads.

Performance on a POWER9 running in SMT4 mode improves 12% with this patch.

Signed-off-by: Anton Blanchard <anton@ozlabs.org>