### PR TITLE
Aligned memory

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,20 @@
-Changes in version 7.3, 03/12/2018
+Changes in version 7.3, 09/12/2018
 ==================================
 
 Unreleased, work in progress.
 
+This is a minor new release, the API and ABI (Application binary
+interface) are backwards compatible.
+
+primesieve-7.3 improves the cache efficiency of the sieving algorithm
+for large sieving primes. By using aligned memory it is possible
+to reduce the number of pointer indirections which reduces cache
+pollution. I have measured a speed up of 15% near 1e18 and a speed up
+of 25% near 1e19.
+
+* EratBig.cpp: Improve cache efficiency.
+* MemoryPoop.cpp: Allocate buckets aligned by sizeof(Bucket).
+* Bucket.hpp: sizeof(Bucket) is now power of 2.
 * primesieve::iterator: Support C++ move semantics.
 
 Changes in version 7.2, 26/10/2018

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -130,6 +130,16 @@ private:
 
 static_assert(isPow2(sizeof(Bucket)), "sizeof(Bucket) must be a power of 2");
 
+/// Get the current sieving prime's bucket.
+/// For performance reasons we don't keep an array with
+/// all buckets. Instead we find the sieving prime's bucket
+/// by doing pointer arithmetic using the sieving prime's
+/// address. Since all buckets are aligned by
+/// sizeof(Bucket) we calculate the next address that is
+/// smaller than the sieving prime's address and that
+/// is aligned by sizeof(Bucket). That's the address of
+/// the sieving prime's bucket.
+///
 inline Bucket* SievingPrime::getBucket() const
 {
   std::size_t address = (std::size_t) this;
@@ -140,6 +150,11 @@ inline Bucket* SievingPrime::getBucket() const
   return (Bucket*) BucketAddress;
 }
 
+/// Returns true if the sieving prime's bucket is full.
+/// Since each bucket's memory is aligned by sizeof(Bucket)
+/// we can compute the position of the current sieving
+/// prime using address % sizeof(Bucket).
+///
 inline bool SievingPrime::isBucketFull() const
 {
   std::size_t address = (std::size_t) this;
@@ -147,6 +162,10 @@ inline bool SievingPrime::isBucketFull() const
   return address % sizeof(Bucket) == 0;
 }
 
+/// Returns true if the sieving prime's bucket is empty
+/// and if that bucket does not have a pointer to other
+/// buckets full with sieving primes.
+///
 inline bool SievingPrime::empty() const
 {
   std::size_t address = (std::size_t) this;

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -115,12 +115,12 @@ public:
   void setEnd(SievingPrime* end) { end_ = end; }
   void reset() { end_ = begin(); }
 
+private:
   enum {
     SIEVING_PRIMES_OFFSET = sizeof(SievingPrime*) + sizeof(Bucket*),
     SIEVING_PRIMES_SIZE = (config::BUCKET_BYTES - SIEVING_PRIMES_OFFSET) / sizeof(SievingPrime)
   };
 
-private:
   SievingPrime* end_;
   Bucket* next_;
   SievingPrime sievingPrimes_[SIEVING_PRIMES_SIZE];

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -31,8 +31,7 @@ namespace primesieve {
 class SievingPrime
 {
 public:
-  enum
-  {
+  enum {
     MAX_MULTIPLEINDEX = (1 << 23) - 1,
     MAX_WHEELINDEX    = (1 << (32 - 23)) - 1
   };
@@ -115,12 +114,16 @@ public:
   void setNext(Bucket* next) { next_ = next; }
   void setEnd(SievingPrime* end) { end_ = end; }
   void reset() { end_ = begin(); }
-  enum { SIEVING_PRIMES_OFFSET = sizeof(SievingPrime*) + sizeof(Bucket*) };
+
+  enum {
+    SIEVING_PRIMES_OFFSET = sizeof(SievingPrime*) + sizeof(Bucket*),
+    SIEVING_PRIMES_SIZE = (config::BUCKET_BYTES - SIEVING_PRIMES_OFFSET) / sizeof(SievingPrime)
+  };
 
 private:
   SievingPrime* end_;
   Bucket* next_;
-  SievingPrime sievingPrimes_[(config::BUCKET_BYTES - SIEVING_PRIMES_OFFSET) / sizeof(SievingPrime)];
+  SievingPrime sievingPrimes_[SIEVING_PRIMES_SIZE];
 };
 
 static_assert(isPow2(sizeof(Bucket)), "sizeof(Bucket) must be a power of 2!");

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -113,7 +113,6 @@ private:
 class Bucket
 {
 public:
-  Bucket() = delete;
   SievingPrime* begin() { return &sievingPrimes_[0]; }
   SievingPrime* end()   { return end_; }
   Bucket* next()        { return next_; }
@@ -145,7 +144,7 @@ inline bool SievingPrime::isBucketFull() const
 {
   std::size_t address = (std::size_t) this;
   address += sizeof(SievingPrime);
-  return (address % sizeof(Bucket)) == 0;
+  return address % sizeof(Bucket) == 0;
 }
 
 inline bool SievingPrime::empty() const

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -115,11 +115,12 @@ public:
   void setNext(Bucket* next) { next_ = next; }
   void setEnd(SievingPrime* end) { end_ = end; }
   void reset() { end_ = begin(); }
+  enum { SIEVING_PRIMES_OFFSET = sizeof(SievingPrime*) + sizeof(Bucket*) };
 
 private:
   SievingPrime* end_;
   Bucket* next_;
-  SievingPrime sievingPrimes_[(config::BUCKET_BYTES - sizeof(SievingPrime*) - sizeof(Bucket*)) / sizeof(SievingPrime)];
+  SievingPrime sievingPrimes_[(config::BUCKET_BYTES - SIEVING_PRIMES_OFFSET) / sizeof(SievingPrime)];
 };
 
 static_assert(isPow2(sizeof(Bucket)), "sizeof(Bucket) must be a power of 2!");

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -1,7 +1,7 @@
 ///
 /// @file   Bucket.hpp
-/// @brief  A bucket is a container for sieving primes. The
-///         Bucket class is designed as a singly linked list,
+/// @brief  A bucket is a container for sieving primes.
+///         The Bucket class is designed as a singly linked list,
 ///         once there is no more space in the current Bucket
 ///         a new Bucket is allocated.
 ///
@@ -131,14 +131,14 @@ private:
 static_assert(isPow2(sizeof(Bucket)), "sizeof(Bucket) must be a power of 2");
 
 /// Get the current sieving prime's bucket.
-/// For performance reasons we don't keep an array with
-/// all buckets. Instead we find the sieving prime's bucket
-/// by doing pointer arithmetic using the sieving prime's
-/// address. Since all buckets are aligned by
-/// sizeof(Bucket) we calculate the next address that is
-/// smaller than the sieving prime's address and that
-/// is aligned by sizeof(Bucket). That's the address of
-/// the sieving prime's bucket.
+/// For performance reasons we don't keep an array with all
+/// buckets. Instead we find the sieving prime's bucket by
+/// doing pointer arithmetic using the sieving prime's
+/// address. Since all buckets are aligned by sizeof(Bucket)
+/// we calculate the next address that is smaller than the
+/// sieving prime's address and that is aligned by
+/// sizeof(Bucket). That's the address of the sieving prime's
+/// bucket.
 ///
 inline Bucket* SievingPrime::getBucket() const
 {

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -146,8 +146,8 @@ inline Bucket* SievingPrime::getBucket() const
   // We need to adjust the address
   // in case the bucket is full
   address -= 1;
-  std::size_t BucketAddress = address - address % sizeof(Bucket);
-  return (Bucket*) BucketAddress;
+  address -= address % sizeof(Bucket);
+  return (Bucket*) address;
 }
 
 /// Returns true if the sieving prime's bucket is full.

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -158,8 +158,7 @@ inline Bucket* SievingPrime::getBucket() const
 inline bool SievingPrime::isBucketFull() const
 {
   std::size_t address = (std::size_t) this;
-  address += sizeof(SievingPrime);
-  return address % sizeof(Bucket) == 0;
+  return (address + sizeof(SievingPrime)) % sizeof(Bucket) == 0;
 }
 
 /// Returns true if the sieving prime's bucket is empty
@@ -169,8 +168,8 @@ inline bool SievingPrime::isBucketFull() const
 inline bool SievingPrime::empty() const
 {
   std::size_t address = (std::size_t) this;
-  std::size_t offset = sizeof(SievingPrime*) + sizeof(Bucket*);
-  bool isEmpty = (address % sizeof(Bucket)) == offset;
+  std::size_t begin = sizeof(SievingPrime*) + sizeof(Bucket*);
+  bool isEmpty = (address % sizeof(Bucket)) == begin;
   return isEmpty && !getBucket()->hasNext();
 }
 

--- a/include/primesieve/EratBig.hpp
+++ b/include/primesieve/EratBig.hpp
@@ -35,7 +35,7 @@ private:
   uint64_t maxPrime_;
   uint64_t log2SieveSize_;
   uint64_t moduloSieveSize_;
-  std::vector<SievingPrime*> lists_;
+  std::vector<SievingPrime*> sievingPrimes_;
   MemoryPool memoryPool_;
   bool enabled_ = false;
   void init(uint64_t);

--- a/include/primesieve/EratBig.hpp
+++ b/include/primesieve/EratBig.hpp
@@ -10,7 +10,6 @@
 #ifndef ERATBIG_HPP
 #define ERATBIG_HPP
 
-#include "Bucket.hpp"
 #include "MemoryPool.hpp"
 #include "Wheel.hpp"
 #include "types.hpp"
@@ -19,6 +18,8 @@
 #include <vector>
 
 namespace primesieve {
+
+class SievingPrime;
 
 /// EratBig is an implementation of the segmented sieve of
 /// Eratosthenes optimized for big sieving primes that have
@@ -39,7 +40,6 @@ private:
   bool enabled_ = false;
   void init(uint64_t);
   void storeSievingPrime(uint64_t, uint64_t, uint64_t);
-  void moveSievingPrime(SievingPrime*&, uint64_t, uint64_t, uint64_t);
   void crossOff(byte_t*, SievingPrime*, SievingPrime*);
 };
 

--- a/include/primesieve/EratBig.hpp
+++ b/include/primesieve/EratBig.hpp
@@ -34,12 +34,12 @@ private:
   uint64_t maxPrime_;
   uint64_t log2SieveSize_;
   uint64_t moduloSieveSize_;
-  /// Vector of bucket lists, holds the sieving primes
-  std::vector<Bucket*> lists_;
+  std::vector<SievingPrime*> lists_;
   MemoryPool memoryPool_;
   bool enabled_ = false;
   void init(uint64_t);
   void storeSievingPrime(uint64_t, uint64_t, uint64_t);
+  void moveSievingPrime(SievingPrime*&, uint64_t, uint64_t, uint64_t);
   void crossOff(byte_t*, SievingPrime*, SievingPrime*);
 };
 

--- a/include/primesieve/EratMedium.hpp
+++ b/include/primesieve/EratMedium.hpp
@@ -36,8 +36,8 @@ private:
   bool enabled_ = false;
   uint64_t maxPrime_;
   MemoryPool memoryPool_;
-  std::array<SievingPrime*, 64> lists_;
-  void resetLists();
+  std::array<SievingPrime*, 64> sievingPrimes_;
+  void resetSievingPrimes();
   void storeSievingPrime(uint64_t, uint64_t, uint64_t);
   void crossOff(byte_t*, byte_t*, Bucket*);
   void crossOff_7(byte_t*, byte_t*, Bucket*);

--- a/include/primesieve/EratMedium.hpp
+++ b/include/primesieve/EratMedium.hpp
@@ -34,9 +34,10 @@ private:
   bool enabled_ = false;
   uint64_t maxPrime_;
   MemoryPool memoryPool_;
-  std::array<Bucket*, 64> lists_;
+  std::array<SievingPrime*, 64> lists_;
   void resetLists();
   void storeSievingPrime(uint64_t, uint64_t, uint64_t);
+  void moveSievingPrime(uint64_t, uint64_t, uint64_t);
   void crossOff(byte_t*, byte_t*, Bucket*);
   void crossOff_7(byte_t*, byte_t*, Bucket*);
   void crossOff_11(byte_t*, byte_t*, Bucket*);

--- a/include/primesieve/EratMedium.hpp
+++ b/include/primesieve/EratMedium.hpp
@@ -11,7 +11,6 @@
 #define ERATMEDIUM_HPP
 
 #include "MemoryPool.hpp"
-#include "Bucket.hpp"
 #include "types.hpp"
 #include "Wheel.hpp"
 
@@ -19,6 +18,9 @@
 #include <array>
 
 namespace primesieve {
+
+class Bucket;
+class SievingPrime;
 
 /// EratMedium is an implementation of the segmented sieve of
 /// Eratosthenes optimized for medium sieving primes
@@ -37,7 +39,6 @@ private:
   std::array<SievingPrime*, 64> lists_;
   void resetLists();
   void storeSievingPrime(uint64_t, uint64_t, uint64_t);
-  void moveSievingPrime(uint64_t, uint64_t, uint64_t);
   void crossOff(byte_t*, byte_t*, Bucket*);
   void crossOff_7(byte_t*, byte_t*, Bucket*);
   void crossOff_11(byte_t*, byte_t*, Bucket*);

--- a/include/primesieve/MemoryPool.hpp
+++ b/include/primesieve/MemoryPool.hpp
@@ -48,21 +48,10 @@ public:
   /// compute the position of the current sieving prime using
   /// address % sizeof(Bucket).
   ///
-  static bool isBucketFull(SievingPrime* sievingPrime)
+  static bool isFullBucket(SievingPrime* sievingPrime)
   {
     std::size_t address = (std::size_t) sievingPrime;
     return address % sizeof(Bucket) == 0;
-  }
-
-  /// Returns true if the sieving prime's bucket is empty
-  /// and if that bucket does not have a pointer to other
-  /// buckets full with sieving primes.
-  ///
-  static bool isEmpty(SievingPrime* sievingPrime)
-  {
-    std::size_t address = (std::size_t) sievingPrime;
-    bool isEmpty = (address % sizeof(Bucket)) == Bucket::SIEVING_PRIMES_OFFSET;
-    return isEmpty && !getBucket(sievingPrime)->hasNext();
   }
 
 private:

--- a/include/primesieve/MemoryPool.hpp
+++ b/include/primesieve/MemoryPool.hpp
@@ -26,6 +26,7 @@ public:
   void freeBucket(Bucket* bucket);
 private:
   void allocateBuckets();
+  void initBuckets(Bucket* buckets);
   void increaseAllocCount();
   /// List of empty buckets
   Bucket* stock_ = nullptr;

--- a/include/primesieve/MemoryPool.hpp
+++ b/include/primesieve/MemoryPool.hpp
@@ -10,19 +10,21 @@
 #ifndef MEMORYPOOL_HPP
 #define MEMORYPOOL_HPP
 
-#include "Bucket.hpp"
-
 #include <stdint.h>
 #include <vector>
 #include <memory>
 
 namespace primesieve {
 
+class Bucket;
+class SievingPrime;
+
 class MemoryPool
 {
 public:
-  void addBucket(Bucket*& list);
-  void freeBucket(Bucket* b);
+  Bucket* getBucket();
+  void addBucket(SievingPrime*& sievingPrime);
+  void freeBucket(Bucket* bucket);
 private:
   void allocateBuckets();
   void increaseAllocCount();

--- a/include/primesieve/MemoryPool.hpp
+++ b/include/primesieve/MemoryPool.hpp
@@ -10,7 +10,6 @@
 #ifndef MEMORYPOOL_HPP
 #define MEMORYPOOL_HPP
 
-#include <stdint.h>
 #include <vector>
 #include <memory>
 
@@ -22,7 +21,7 @@ class SievingPrime;
 class MemoryPool
 {
 public:
-  Bucket* getBucket();
+  void reset(SievingPrime*& sievingPrime);
   void addBucket(SievingPrime*& sievingPrime);
   void freeBucket(Bucket* bucket);
 private:
@@ -31,7 +30,7 @@ private:
   /// List of empty buckets
   Bucket* stock_ = nullptr;
   /// Number of buckets to allocate
-  uint64_t count_ = 128;
+  std::size_t count_ = 128;
   /// Pointers of allocated buckets
   std::vector<std::unique_ptr<char[]>> memory_;
 };

--- a/include/primesieve/MemoryPool.hpp
+++ b/include/primesieve/MemoryPool.hpp
@@ -13,8 +13,8 @@
 #include "Bucket.hpp"
 
 #include <stdint.h>
-#include <memory>
 #include <vector>
+#include <memory>
 
 namespace primesieve {
 
@@ -31,7 +31,7 @@ private:
   /// Number of buckets to allocate
   uint64_t count_ = 128;
   /// Pointers of allocated buckets
-  std::vector<std::unique_ptr<Bucket[]>> memory_;
+  std::vector<std::unique_ptr<char[]>> memory_;
 };
 
 } // namespace

--- a/include/primesieve/MemoryPool.hpp
+++ b/include/primesieve/MemoryPool.hpp
@@ -61,8 +61,7 @@ public:
   static bool isEmpty(SievingPrime* sievingPrime)
   {
     std::size_t address = (std::size_t) sievingPrime;
-    std::size_t begin = sizeof(SievingPrime*) + sizeof(Bucket*);
-    bool isEmpty = (address % sizeof(Bucket)) == begin;
+    bool isEmpty = (address % sizeof(Bucket)) == Bucket::SIEVING_PRIMES_OFFSET;
     return isEmpty && !getBucket(sievingPrime)->hasNext();
   }
 

--- a/include/primesieve/config.hpp
+++ b/include/primesieve/config.hpp
@@ -24,12 +24,13 @@ namespace config {
 enum {
   /// Number of sieving primes per Bucket in EratSmall, EratMedium
   /// and EratBig objects, affects performance by about 3%.
+  /// @pre BUCKET_BYTES must be a power of 2.
   ///
-  /// - For x86-64 CPUs after  2010 use 1024
-  /// - For x86-64 CPUs before 2010 use 512
-  /// - For PowerPC G4 CPUs    2003 use 256
+  /// - For x86-64 CPUs after  2010 use 8192
+  /// - For x86-64 CPUs before 2010 use 4096
+  /// - For PowerPC G4 CPUs    2003 use 2048
   ///
-  BUCKETSIZE = 1 << 10,
+  BUCKET_BYTES = 1 << 13,
 
   /// The MemoryPool allocates at most MAX_ALLOC_BYTES of new
   /// memory when it runs out of buckets.

--- a/include/primesieve/pmath.hpp
+++ b/include/primesieve/pmath.hpp
@@ -27,7 +27,7 @@ inline X ceilDiv(X x, Y y)
 }
 
 template <typename T>
-inline bool isPow2(T x)
+constexpr bool isPow2(T x)
 {
   return x != 0 && (x & (x - 1)) == 0;
 }

--- a/src/EratBig.cpp
+++ b/src/EratBig.cpp
@@ -73,7 +73,8 @@ void EratBig::storeSievingPrime(uint64_t prime, uint64_t multipleIndex, uint64_t
   uint64_t segment = multipleIndex >> log2SieveSize_;
   multipleIndex &= moduloSieveSize_;
 
-  if (!sievingPrimes_[segment]++->set(sievingPrime, multipleIndex, wheelIndex))
+  sievingPrimes_[segment]++->set(sievingPrime, multipleIndex, wheelIndex);
+  if (memoryPool_.isBucketFull(sievingPrimes_[segment]))
     memoryPool_.addBucket(sievingPrimes_[segment]);
 }
 
@@ -83,9 +84,9 @@ void EratBig::storeSievingPrime(uint64_t prime, uint64_t multipleIndex, uint64_t
 ///
 void EratBig::crossOff(byte_t* sieve)
 {
-  while (!sievingPrimes_[0]->empty())
+  while (!memoryPool_.isEmpty(sievingPrimes_[0]))
   {
-    Bucket* bucket = sievingPrimes_[0]->getBucket();
+    Bucket* bucket = memoryPool_.getBucket(sievingPrimes_[0]);
     bucket->setEnd(sievingPrimes_[0]);
     memoryPool_.reset(sievingPrimes_[0]);
 
@@ -136,9 +137,12 @@ void EratBig::crossOff(byte_t* sieve, SievingPrime* prime, SievingPrime* end)
 
     // move the 2 sieving primes to the list related
     // to their next multiple's segment
-    if (!sievingPrimes[segment0]++->set(sievingPrime0, multipleIndex0, wheelIndex0))
+    sievingPrimes[segment0]++->set(sievingPrime0, multipleIndex0, wheelIndex0);
+    if (memoryPool_.isBucketFull(sievingPrimes[segment0]))
       memoryPool_.addBucket(sievingPrimes[segment0]);
-    if (!sievingPrimes[segment1]++->set(sievingPrime1, multipleIndex1, wheelIndex1))
+
+    sievingPrimes[segment1]++->set(sievingPrime1, multipleIndex1, wheelIndex1);
+    if (memoryPool_.isBucketFull(sievingPrimes[segment1]))
       memoryPool_.addBucket(sievingPrimes[segment1]);
   }
 
@@ -152,7 +156,8 @@ void EratBig::crossOff(byte_t* sieve, SievingPrime* prime, SievingPrime* end)
     uint64_t segment = multipleIndex >> log2SieveSize;
     multipleIndex &= moduloSieveSize;
 
-    if (!sievingPrimes[segment]++->set(sievingPrime, multipleIndex, wheelIndex))
+    sievingPrimes[segment]++->set(sievingPrime, multipleIndex, wheelIndex);
+    if (memoryPool_.isBucketFull(sievingPrimes[segment]))
       memoryPool_.addBucket(sievingPrimes[segment]);
   }
 }

--- a/src/EratBig.cpp
+++ b/src/EratBig.cpp
@@ -141,8 +141,8 @@ void EratBig::crossOff(byte_t* sieve, SievingPrime* prime, SievingPrime* end)
     multipleIndex0 &= moduloSieveSize;
     multipleIndex1 &= moduloSieveSize;
 
-    // move the 2 sieving primes to the list related
-    // to their next multiple's segment
+    // move the sieving prime to the list related
+    // to the segment of its next multiple
     sievingPrimes[segment0]++->set(sievingPrime0, multipleIndex0, wheelIndex0);
     if (memoryPool_.isFullBucket(sievingPrimes[segment0]))
       memoryPool_.addBucket(sievingPrimes[segment0]);

--- a/src/EratBig.cpp
+++ b/src/EratBig.cpp
@@ -108,7 +108,7 @@ void EratBig::crossOff(byte_t* sieve)
 /// multiples per segment. Cross-off the next multiple of
 /// each sieving prime in the current bucket.
 ///
-void EratBig::crossOff(byte_t* sieve, SievingPrime* primes, SievingPrime* end)
+void EratBig::crossOff(byte_t* sieve, SievingPrime* prime, SievingPrime* end)
 {
   SievingPrime** sievingPrimes = &sievingPrimes_[0];
   uint64_t moduloSieveSize = moduloSieveSize_;
@@ -116,14 +116,14 @@ void EratBig::crossOff(byte_t* sieve, SievingPrime* primes, SievingPrime* end)
 
   // 2 sieving primes are processed per loop iteration
   // to increase instruction level parallelism
-  for (; primes + 2 <= end; primes += 2)
+  for (; prime + 2 <= end; prime += 2)
   { 
-    uint64_t multipleIndex0 = primes[0].getMultipleIndex();
-    uint64_t wheelIndex0    = primes[0].getWheelIndex();
-    uint64_t sievingPrime0  = primes[0].getSievingPrime();
-    uint64_t multipleIndex1 = primes[1].getMultipleIndex();
-    uint64_t wheelIndex1    = primes[1].getWheelIndex();
-    uint64_t sievingPrime1  = primes[1].getSievingPrime();
+    uint64_t multipleIndex0 = prime[0].getMultipleIndex();
+    uint64_t wheelIndex0    = prime[0].getWheelIndex();
+    uint64_t sievingPrime0  = prime[0].getSievingPrime();
+    uint64_t multipleIndex1 = prime[1].getMultipleIndex();
+    uint64_t wheelIndex1    = prime[1].getWheelIndex();
+    uint64_t sievingPrime1  = prime[1].getSievingPrime();
 
     // cross-off the current multiple (unset bit)
     // and calculate the next multiple
@@ -142,11 +142,11 @@ void EratBig::crossOff(byte_t* sieve, SievingPrime* primes, SievingPrime* end)
       memoryPool_.addBucket(sievingPrimes[segment1]);
   }
 
-  if (primes != end)
+  if (prime != end)
   {
-    uint64_t multipleIndex = primes->getMultipleIndex();
-    uint64_t wheelIndex    = primes->getWheelIndex();
-    uint64_t sievingPrime  = primes->getSievingPrime();
+    uint64_t multipleIndex = prime->getMultipleIndex();
+    uint64_t wheelIndex    = prime->getWheelIndex();
+    uint64_t sievingPrime  = prime->getSievingPrime();
 
     unsetBit(sieve, sievingPrime, &multipleIndex, &wheelIndex);
     uint64_t segment = multipleIndex >> log2SieveSize;

--- a/src/EratBig.cpp
+++ b/src/EratBig.cpp
@@ -62,10 +62,7 @@ void EratBig::init(uint64_t sieveSize)
   sievingPrimes_.resize(size);
 
   for (SievingPrime*& sievingPrime : sievingPrimes_)
-  {
-    Bucket* bucket = memoryPool_.getBucket();
-    sievingPrime = bucket->begin();
-  }
+    memoryPool_.reset(sievingPrime);
 }
 
 /// Add a new sieving prime
@@ -90,8 +87,7 @@ void EratBig::crossOff(byte_t* sieve)
   {
     Bucket* bucket = sievingPrimes_[0]->getBucket();
     bucket->setEnd(sievingPrimes_[0]);
-    Bucket* empty = memoryPool_.getBucket();
-    sievingPrimes_[0] = empty->begin();
+    memoryPool_.reset(sievingPrimes_[0]);
 
     while (bucket)
     {
@@ -114,7 +110,7 @@ void EratBig::crossOff(byte_t* sieve)
 ///
 void EratBig::crossOff(byte_t* sieve, SievingPrime* primes, SievingPrime* end)
 {
-  SievingPrime** sievingPrimes = sievingPrimes_.data();
+  SievingPrime** sievingPrimes = &sievingPrimes_[0];
   uint64_t moduloSieveSize = moduloSieveSize_;
   uint64_t log2SieveSize = log2SieveSize_;
 

--- a/src/EratBig.cpp
+++ b/src/EratBig.cpp
@@ -74,7 +74,7 @@ void EratBig::storeSievingPrime(uint64_t prime, uint64_t multipleIndex, uint64_t
   multipleIndex &= moduloSieveSize_;
 
   sievingPrimes_[segment]++->set(sievingPrime, multipleIndex, wheelIndex);
-  if (memoryPool_.isBucketFull(sievingPrimes_[segment]))
+  if (memoryPool_.isFullBucket(sievingPrimes_[segment]))
     memoryPool_.addBucket(sievingPrimes_[segment]);
 }
 
@@ -84,10 +84,13 @@ void EratBig::storeSievingPrime(uint64_t prime, uint64_t multipleIndex, uint64_t
 ///
 void EratBig::crossOff(byte_t* sieve)
 {
-  while (!memoryPool_.isEmpty(sievingPrimes_[0]))
+  while (true)
   {
     Bucket* bucket = memoryPool_.getBucket(sievingPrimes_[0]);
     bucket->setEnd(sievingPrimes_[0]);
+    if (bucket->empty() && !bucket->hasNext())
+      break;
+
     memoryPool_.reset(sievingPrimes_[0]);
 
     while (bucket)
@@ -99,6 +102,9 @@ void EratBig::crossOff(byte_t* sieve)
     }
   }
 
+  // Move the sieving primes related to the next segment to
+  // the 1st position so that they will be used when
+  // sieving the next segment.
   std::rotate(sievingPrimes_.begin(),
               sievingPrimes_.begin() + 1,
               sievingPrimes_.end());
@@ -138,11 +144,11 @@ void EratBig::crossOff(byte_t* sieve, SievingPrime* prime, SievingPrime* end)
     // move the 2 sieving primes to the list related
     // to their next multiple's segment
     sievingPrimes[segment0]++->set(sievingPrime0, multipleIndex0, wheelIndex0);
-    if (memoryPool_.isBucketFull(sievingPrimes[segment0]))
+    if (memoryPool_.isFullBucket(sievingPrimes[segment0]))
       memoryPool_.addBucket(sievingPrimes[segment0]);
 
     sievingPrimes[segment1]++->set(sievingPrime1, multipleIndex1, wheelIndex1);
-    if (memoryPool_.isBucketFull(sievingPrimes[segment1]))
+    if (memoryPool_.isFullBucket(sievingPrimes[segment1]))
       memoryPool_.addBucket(sievingPrimes[segment1]);
   }
 
@@ -157,7 +163,7 @@ void EratBig::crossOff(byte_t* sieve, SievingPrime* prime, SievingPrime* end)
     multipleIndex &= moduloSieveSize;
 
     sievingPrimes[segment]++->set(sievingPrime, multipleIndex, wheelIndex);
-    if (memoryPool_.isBucketFull(sievingPrimes[segment]))
+    if (memoryPool_.isFullBucket(sievingPrimes[segment]))
       memoryPool_.addBucket(sievingPrimes[segment]);
   }
 }

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -83,7 +83,11 @@ void EratMedium::crossOff(byte_t* sieve, uint64_t sieveSize)
   auto copy = sievingPrimes_;
   resetSievingPrimes();
 
-  // Iterate over 64 bucket lists
+  // Iterate over all bucket lists.
+  // The 1st list contains sieving primes with wheelIndex = 0.
+  // The 2nd list contains sieving primes with wheelIndex = 1.
+  // The 3rd list contains sieving primes with wheelIndex = 2.
+  // ...
   for (SievingPrime* sievingPrime : copy)
   {
     Bucket* bucket = sievingPrime->getBucket();

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -36,7 +36,8 @@
 #define SORT_SIEVING_PRIME(wheelIndex) \
   sort ## wheelIndex: \
   multipleIndex = (uint64_t) (p - sieveEnd); \
-  moveSievingPrime(sievingPrime, multipleIndex, wheelIndex); \
+  if (!lists_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex)) \
+    memoryPool_.addBucket(lists_[wheelIndex]); \
   continue;
 
 namespace primesieve {
@@ -66,31 +67,15 @@ void EratMedium::storeSievingPrime(uint64_t prime, uint64_t multipleIndex, uint6
 {
   assert(prime <= maxPrime_);
   uint64_t sievingPrime = prime / 30;
-  moveSievingPrime(sievingPrime, multipleIndex, wheelIndex);
-}
-
-/// Move the sieving prime to the list related
-/// to the sieving prime's wheelIndex.
-///
-void EratMedium::moveSievingPrime(uint64_t prime, uint64_t multipleIndex, uint64_t wheelIndex)
-{
-  SievingPrime*& sievingPrime = lists_[wheelIndex];
-
-  if (!sievingPrime++->set(prime, multipleIndex, wheelIndex))
-  {
-    Bucket* bucket = sievingPrime->getBucket();
-    bucket->setEnd(sievingPrime);
-    memoryPool_.addBucket(bucket);
-    sievingPrime = bucket->begin();
-  }
+  if (!lists_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex))
+    memoryPool_.addBucket(lists_[wheelIndex]);
 }
 
 void EratMedium::resetLists()
 {
   for (SievingPrime*& sievingPrime : lists_)
   {
-    Bucket* bucket = nullptr;
-    memoryPool_.addBucket(bucket);
+    Bucket* bucket = memoryPool_.getBucket();
     sievingPrime = bucket->begin();
   }
 }

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -62,6 +62,12 @@ void EratMedium::init(uint64_t stop, uint64_t sieveSize, uint64_t maxPrime)
   resetSievingPrimes();
 }
 
+void EratMedium::resetSievingPrimes()
+{
+  for (SievingPrime*& sievingPrime : sievingPrimes_)
+    memoryPool_.reset(sievingPrime);
+}
+
 /// Add a new sieving prime to EratMedium
 void EratMedium::storeSievingPrime(uint64_t prime, uint64_t multipleIndex, uint64_t wheelIndex)
 {
@@ -69,15 +75,6 @@ void EratMedium::storeSievingPrime(uint64_t prime, uint64_t multipleIndex, uint6
   uint64_t sievingPrime = prime / 30;
   if (!sievingPrimes_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex))
     memoryPool_.addBucket(sievingPrimes_[wheelIndex]);
-}
-
-void EratMedium::resetSievingPrimes()
-{
-  for (SievingPrime*& sievingPrime : sievingPrimes_)
-  {
-    Bucket* bucket = memoryPool_.getBucket();
-    sievingPrime = bucket->begin();
-  }
 }
 
 void EratMedium::crossOff(byte_t* sieve, uint64_t sieveSize)

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -37,7 +37,7 @@
   sort ## wheelIndex: \
   multipleIndex = (uint64_t) (p - sieveEnd); \
   sievingPrimes_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex); \
-  if (memoryPool_.isBucketFull(sievingPrimes_[wheelIndex])) \
+  if (memoryPool_.isFullBucket(sievingPrimes_[wheelIndex])) \
     memoryPool_.addBucket(sievingPrimes_[wheelIndex]); \
   continue;
 
@@ -75,7 +75,7 @@ void EratMedium::storeSievingPrime(uint64_t prime, uint64_t multipleIndex, uint6
   assert(prime <= maxPrime_);
   uint64_t sievingPrime = prime / 30;
   sievingPrimes_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex);
-  if (memoryPool_.isBucketFull(sievingPrimes_[wheelIndex]))
+  if (memoryPool_.isFullBucket(sievingPrimes_[wheelIndex]))
     memoryPool_.addBucket(sievingPrimes_[wheelIndex]);
 }
 

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -36,7 +36,8 @@
 #define SORT_SIEVING_PRIME(wheelIndex) \
   sort ## wheelIndex: \
   multipleIndex = (uint64_t) (p - sieveEnd); \
-  if (!sievingPrimes_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex)) \
+  sievingPrimes_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex); \
+  if (memoryPool_.isBucketFull(sievingPrimes_[wheelIndex])) \
     memoryPool_.addBucket(sievingPrimes_[wheelIndex]); \
   continue;
 
@@ -73,7 +74,8 @@ void EratMedium::storeSievingPrime(uint64_t prime, uint64_t multipleIndex, uint6
 {
   assert(prime <= maxPrime_);
   uint64_t sievingPrime = prime / 30;
-  if (!sievingPrimes_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex))
+  sievingPrimes_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex);
+  if (memoryPool_.isBucketFull(sievingPrimes_[wheelIndex]))
     memoryPool_.addBucket(sievingPrimes_[wheelIndex]);
 }
 
@@ -90,7 +92,7 @@ void EratMedium::crossOff(byte_t* sieve, uint64_t sieveSize)
   // ...
   for (SievingPrime* sievingPrime : copy)
   {
-    Bucket* bucket = sievingPrime->getBucket();
+    Bucket* bucket = memoryPool_.getBucket(sievingPrime);
     bucket->setEnd(sievingPrime);
 
     // Iterate over the current bucket list.

--- a/src/MemoryPool.cpp
+++ b/src/MemoryPool.cpp
@@ -27,7 +27,6 @@
 
 using std::size_t;
 using std::unique_ptr;
-using primesieve::primesieve_error;
 
 namespace primesieve {
 

--- a/src/MemoryPool.cpp
+++ b/src/MemoryPool.cpp
@@ -25,6 +25,8 @@
 #include <memory>
 #include <vector>
 
+using namespace std;
+
 namespace primesieve {
 
 void MemoryPool::addBucket(Bucket*& list)
@@ -52,9 +54,16 @@ void MemoryPool::allocateBuckets()
   if (memory_.empty())
     memory_.reserve(128);
 
-  using std::unique_ptr;
-  Bucket* buckets = new Bucket[count_];
-  memory_.emplace_back(unique_ptr<Bucket[]>(buckets));
+  // allocate a large chunk of memory
+  size_t bytes = sizeof(Bucket) * count_;
+  bytes += sizeof(Bucket) - 1;
+  char* memory = new char[bytes];
+  memory_.emplace_back(unique_ptr<char[]>(memory));
+
+  // convert raw memory into buckets
+  void* ptr = memory;
+  ptr = std::align(sizeof(Bucket), sizeof(Bucket), ptr, bytes);
+  Bucket* buckets = (Bucket*) ptr;
 
   // initialize buckets
   for (uint64_t i = 0; i < count_; i++)

--- a/src/MemoryPool.cpp
+++ b/src/MemoryPool.cpp
@@ -20,25 +20,24 @@
 #include <primesieve/config.hpp>
 #include <primesieve/Bucket.hpp>
 
-#include <stdint.h>
 #include <algorithm>
 #include <memory>
 #include <vector>
 
-using namespace std;
+using std::size_t;
+using std::unique_ptr;
 
 namespace primesieve {
 
-Bucket* MemoryPool::getBucket()
+void MemoryPool::reset(SievingPrime*& sievingPrime)
 {
   if (!stock_)
     allocateBuckets();
 
-  // get first bucket
   Bucket* bucket = stock_;
   stock_ = stock_->next();
   bucket->setNext(nullptr);
-  return bucket;
+  sievingPrime = bucket->begin();
 }
 
 void MemoryPool::addBucket(SievingPrime*& sievingPrime)
@@ -79,7 +78,7 @@ void MemoryPool::allocateBuckets()
   Bucket* buckets = (Bucket*) ptr;
 
   // initialize buckets
-  for (uint64_t i = 0; i < count_; i++)
+  for (size_t i = 0; i < count_; i++)
   {
     Bucket* next = nullptr;
     if (i + 1 < count_)
@@ -96,7 +95,7 @@ void MemoryPool::allocateBuckets()
 void MemoryPool::increaseAllocCount()
 {
   count_ += count_ / 8;
-  uint64_t maxCount = config::MAX_ALLOC_BYTES / sizeof(Bucket);
+  size_t maxCount = config::MAX_ALLOC_BYTES / sizeof(Bucket);
   count_ = std::min(count_, maxCount);
 }
 

--- a/src/MemoryPool.cpp
+++ b/src/MemoryPool.cpp
@@ -29,24 +29,37 @@ using namespace std;
 
 namespace primesieve {
 
-void MemoryPool::addBucket(Bucket*& list)
+Bucket* MemoryPool::getBucket()
 {
   if (!stock_)
     allocateBuckets();
 
   // get first bucket
-  Bucket& bucket = *stock_;
+  Bucket* bucket = stock_;
   stock_ = stock_->next();
-  bucket.setNext(list);
-  list = &bucket;
+  bucket->setNext(nullptr);
+  return bucket;
 }
 
-void MemoryPool::freeBucket(Bucket* b)
+void MemoryPool::addBucket(SievingPrime*& sievingPrime)
 {
-  Bucket& bucket = *b;
-  bucket.reset();
-  bucket.setNext(stock_);
-  stock_ = &bucket;
+  if (!stock_)
+    allocateBuckets();
+
+  Bucket* bucket = stock_;
+  stock_ = stock_->next();
+
+  Bucket* old = sievingPrime->getBucket();
+  old->setEnd(sievingPrime);
+  bucket->setNext(old);
+  sievingPrime = bucket->begin();
+}
+
+void MemoryPool::freeBucket(Bucket* bucket)
+{
+  bucket->reset();
+  bucket->setNext(stock_);
+  stock_ = bucket;
 }
 
 void MemoryPool::allocateBuckets()

--- a/src/MemoryPool.cpp
+++ b/src/MemoryPool.cpp
@@ -49,7 +49,7 @@ void MemoryPool::addBucket(SievingPrime*& sievingPrime)
   Bucket* bucket = stock_;
   stock_ = stock_->next();
 
-  Bucket* old = sievingPrime->getBucket();
+  Bucket* old = getBucket(sievingPrime);
   old->setEnd(sievingPrime);
   bucket->setNext(old);
   sievingPrime = bucket->begin();


### PR DESCRIPTION
This pull request improves the cache efficiency of the sieving algorithm for large sieving primes. By using aligned memory it is possible to reduce the number of pointer indirections which reduces cache pollution. I have measured a speed up of 15% near 1e18 and a speed up of 25% near 1e19.