### PR TITLE
primesieve.pc.in: Use CMAKE_INSTALL_FULL_BINDIR, etc.

### DIFF
--- a/primesieve.pc.in
+++ b/primesieve.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-bindir=${prefix}/@CMAKE_INSTALL_BINDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+bindir=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: primesieve
 Description: Fast C/C++ prime number generator


### PR DESCRIPTION
Previously the `CMAKE_INSTALL_PREFIX` was incorrectly prepended to `CMAKE_INSTALL_BINDIR` even if the latter was already an absolute path. Instead, use the correctly resolved absolute path variables that CMake already provides.
