### PR TITLE
Speeds up PrimeGenerator::fill (proof-of-concept)

### DIFF
--- a/include/primesieve/Erat.hpp
+++ b/include/primesieve/Erat.hpp
@@ -134,6 +134,19 @@ inline uint64_t Erat::nextPrime(uint64_t bits, uint64_t low)
 {
 #if defined(ctz64)
   // Find first set 1 bit
+
+  // Some implementations of ctz64 include an explicit check for the
+  // argument being 0. This is because, for example, the GCC version
+  // of countr_zero is implemented in terms of __builtin_ctz, which is
+  // undefined for 0. But since this function is never (*) called with
+  // bits == 0, we can avoid that check and the associated (untaken)
+  // conditional jump.
+  //
+  // (*) the proposed loop unrolling optimization in
+  // PrimeGenerator::fill actually passes bits == 0 sometimes. On
+  // processors where __builtin_ctzll is truly undefined for bits ==
+  // 0, this may segfault.
+  //  if (bits == 0) UNREACHABLE;
   auto bitIndex = ctz64(bits);
   uint64_t bitValue = bitValues[bitIndex];
   uint64_t prime = low + bitValue;

--- a/src/PrimeGenerator.cpp
+++ b/src/PrimeGenerator.cpp
@@ -28,6 +28,8 @@
 
 using namespace std;
 
+uint64_t popcount64(uint64_t x);
+
 namespace {
 
 /// First 128 primes
@@ -310,7 +312,7 @@ void PrimeGenerator::fill(vector<uint64_t>& primes,
       uint64_t bits = littleendian_cast<uint64_t>(&sieve[sieveIdx]);
 
       size_t j = i;
-      i += __builtin_popcountll(bits);
+      i += popcount64(bits);
 
       // Note that bits may become 0 in the middle of the loop, and
       // then we'd continue writing garbage entries to primes[] until

--- a/src/PrimeGenerator.cpp
+++ b/src/PrimeGenerator.cpp
@@ -311,6 +311,9 @@ void PrimeGenerator::fill(vector<uint64_t>& primes,
     {
       uint64_t bits = littleendian_cast<uint64_t>(&sieve[sieveIdx]);
 
+      // for (; bits != 0; bits &= bits - 1)
+      //   primes[i++] = nextPrime(bits, low);
+
       size_t j = i;
       i += popcount64(bits);
 

--- a/src/PrimeGenerator.cpp
+++ b/src/PrimeGenerator.cpp
@@ -309,8 +309,34 @@ void PrimeGenerator::fill(vector<uint64_t>& primes,
     {
       uint64_t bits = littleendian_cast<uint64_t>(&sieve[sieveIdx]);
 
-      for (; bits != 0; bits &= bits - 1)
-        primes[i++] = nextPrime(bits, low);
+      int j = i;
+      i += __builtin_popcountll(bits);
+
+      // Note that bits may become 0 in the middle of the loop, and
+      // then we'd continue writing garbage entries to primes[] until
+      // the end of the loop is reached. This is not a problem: the
+      // value of i is incremented correctly above, the test "i <=
+      // maxSize - 64" below guarantees that primes[] has enough
+      // space.
+      while (bits) {
+         primes[j+ 0] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+ 1] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+ 2] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+ 3] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+ 4] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+ 5] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+ 6] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+ 7] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+ 8] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+ 9] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+10] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+11] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+12] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+13] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+14] = nextPrime(bits, low); bits &= bits - 1;
+         primes[j+15] = nextPrime(bits, low); bits &= bits - 1;
+         j += 16;
+      }
 
       low += 8 * 30;
       sieveIdx += 8;

--- a/src/PrimeGenerator.cpp
+++ b/src/PrimeGenerator.cpp
@@ -309,7 +309,7 @@ void PrimeGenerator::fill(vector<uint64_t>& primes,
     {
       uint64_t bits = littleendian_cast<uint64_t>(&sieve[sieveIdx]);
 
-      int j = i;
+      size_t j = i;
       i += __builtin_popcountll(bits);
 
       // Note that bits may become 0 in the middle of the loop, and
@@ -318,25 +318,25 @@ void PrimeGenerator::fill(vector<uint64_t>& primes,
       // value of i is incremented correctly above, the test "i <=
       // maxSize - 64" below guarantees that primes[] has enough
       // space.
-      while (bits) {
-         primes[j+ 0] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+ 1] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+ 2] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+ 3] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+ 4] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+ 5] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+ 6] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+ 7] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+ 8] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+ 9] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+10] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+11] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+12] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+13] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+14] = nextPrime(bits, low); bits &= bits - 1;
-         primes[j+15] = nextPrime(bits, low); bits &= bits - 1;
-         j += 16;
-      }
+      do {
+        primes[j+ 0] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+ 1] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+ 2] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+ 3] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+ 4] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+ 5] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+ 6] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+ 7] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+ 8] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+ 9] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+10] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+11] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+12] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+13] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+14] = nextPrime(bits, low); bits &= bits - 1;
+        primes[j+15] = nextPrime(bits, low); bits &= bits - 1;
+        j += 16;
+      } while (j < i);
 
       low += 8 * 30;
       sieveIdx += 8;

--- a/src/popcount.cpp
+++ b/src/popcount.cpp
@@ -22,8 +22,6 @@
 
 #include <stdint.h>
 
-namespace {
-
 /// This uses fewer arithmetic operations than any other known
 /// implementation on machines with fast multiplication.
 /// It uses 12 arithmetic operations, one of which is a multiply.
@@ -41,6 +39,8 @@ uint64_t popcount64(uint64_t x)
   x = (x + (x >> 4)) & m4;
   return (x * h01) >> 56;
 }
+
+namespace {
 
 /// Carry-save adder (CSA).
 /// @see Chapter 5 in "Hacker's Delight".


### PR DESCRIPTION
This pull request is just to start a conversation and check whether you think pursuing this kind of optimization is worthwhile. I realize the code is not ready to be merged into primesieve.

On my laptop (Intel Skylake), this commit reduces the #cycles used by `PrimeGenerator::fill` by about 45%, when used via primesieve::iterator to generate all primes up to 50 billion. Tested with clang only.

At this point, this is a proof-of-concept only. If this direction is aligned with the goals of primesieve, this code would have to be
cleaned and made portable.

There are a number of negative side effects of this approach. The code is more complex than the original. The speed up relies heavily on branch prediction, out-of-order execution, and POPCNT, so it may actually be a regression on other processors (I did not test that). More memory bandwidth is used.

Also, it seems that this code slows down multi-threaded functionality such as NthPrime, PrimePi etc. So primesieve --test is slower.

Stats on Intel Skylake, for generating all primes up to 50 billion.

```
primesieve::iterator it;
__int128_t sum = 0;
for (int64_t p = it.next_prime(); p <= 50'000'000'000; p = it.next_prime())
  sum += p;
cout << sum << endl;
```

Compiled with `clang++-11 -std=c++2a -O3 -pedantic -fomit-frame-pointer -m64 -march=skylake`.

Original code:
```
47,975,954,230      cycles                    #    4.185 GHz
94,568,666,674      instructions              #    1.97  insn per cycle
13,884,302,579      branches                  # 1211.245 M/sec
   561,589,446      branch-misses             #    4.04% of all branches
        23.89%      %cycles in PrimeGenerator::fill
```

New code:
```
42,332,943,051      cycles                    #    4.154 GHz
92,384,340,392      instructions              #    2.18  insn per cycle
11,974,220,227      branches                  # 1174.925 M/sec
   341,654,578      branch-misses             #    2.85% of all branches
        14.62%      %cycles in PrimeGenerator::fill
```