### PR TITLE
8-buffer PreSieve (used to be 4-buffer), estimated 1%-4% speed improvement

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
-Changes in version 7.8, 07/01/2022
+Changes in version 7.8, 11/01/2022
 ==================================
 
-primesieve can now pre-sieve the multiples of primes <= 59
+primesieve can now pre-sieve the multiples of primes < 100
 (previously <= 19) using about the same amount of memory. Instead
 of using a single large pre-sieved buffer primesieve now uses
 4 smaller pre-sieved buffers which are bitwise AND together before

--- a/include/primesieve/PreSieve.hpp
+++ b/include/primesieve/PreSieve.hpp
@@ -6,11 +6,11 @@
 ///         from them at initialization. Each buffer is assigned
 ///         different primes, for example:
 ///
-///         Buffer 0 removes multiplies of: {  7, 61, 73 }
-///         Buffer 1 removes multiplies of: { 11, 53, 59 }
-///         Buffer 2 removes multiplies of: { 13, 37, 71 }
-///         Buffer 3 removes multiplies of: { 17, 29, 67 }
-///         Buffer 4 removes multiplies of: { 19, 41, 43 }
+///         Buffer 0 removes multiplies of: {  7, 67, 71 }
+///         Buffer 1 removes multiplies of: { 11, 41, 73 }
+///         Buffer 2 removes multiplies of: { 13, 43, 59 }
+///         Buffer 3 removes multiplies of: { 17, 37, 53 }
+///         Buffer 4 removes multiplies of: { 19, 29, 61 }
 ///         Buffer 5 removes multiplies of: { 23, 31, 47 }
 ///         Buffer 6 removes multiplies of: { 79, 97 }
 ///         Buffer 7 removes multiplies of: { 83, 89 }

--- a/include/primesieve/PreSieve.hpp
+++ b/include/primesieve/PreSieve.hpp
@@ -40,7 +40,7 @@ public:
 private:
   uint64_t buffersDist_ = 0;
   uint64_t maxPrime_ = 13;
-  std::array<std::vector<uint8_t>, 4> buffers_;
+  std::array<std::vector<uint8_t>, 8> buffers_;
   void initBuffers();
   static void preSieveSmall(uint8_t* sieve, uint64_t sieveSize, uint64_t segmentLow);
   void preSieveLarge(uint8_t* sieve, uint64_t sieveSize, uint64_t segmentLow) const;

--- a/include/primesieve/PreSieve.hpp
+++ b/include/primesieve/PreSieve.hpp
@@ -1,15 +1,19 @@
 ///
 /// @file   PreSieve.hpp
-/// @brief  Pre-sieve multiples of small primes <= 59 to speed up the
+/// @brief  Pre-sieve multiples of small primes < 100 to speed up the
 ///         sieve of Eratosthenes. The idea is to allocate several
 ///         arrays (buffers_) and remove the multiples of small primes
 ///         from them at initialization. Each buffer is assigned
 ///         different primes, for example:
 ///
-///         Buffer 0 removes multiplies of:  7, 19, 23, 29
-///         Buffer 1 removes multiplies of: 11, 13, 17, 37
-///         Buffer 2 removes multiplies of: 31, 47, 59
-///         Buffer 3 removes multiplies of: 41, 43, 53
+///         Buffer 0 removes multiplies of: {  7, 61, 73 }
+///         Buffer 1 removes multiplies of: { 11, 53, 59 }
+///         Buffer 2 removes multiplies of: { 13, 37, 71 }
+///         Buffer 3 removes multiplies of: { 17, 29, 67 }
+///         Buffer 4 removes multiplies of: { 19, 41, 43 }
+///         Buffer 5 removes multiplies of: { 23, 31, 47 }
+///         Buffer 6 removes multiplies of: { 79, 97 }
+///         Buffer 7 removes multiplies of: { 83, 89 }
 ///
 ///         Then whilst sieving, we perform a bitwise AND on the
 ///         buffers_ arrays and store the result in the sieve array.

--- a/src/Erat.cpp
+++ b/src/Erat.cpp
@@ -149,7 +149,7 @@ uint64_t Erat::byteRemainder(uint64_t n)
   return n;
 }
 
-/// Pre-sieve multiples of small primes e.g. <= 59
+/// Pre-sieve multiples of small primes < 100
 /// to speed up the sieve of Eratosthenes
 ///
 void Erat::preSieve()

--- a/src/PreSieve.cpp
+++ b/src/PreSieve.cpp
@@ -6,11 +6,11 @@
 ///         from them at initialization. Each buffer is assigned
 ///         different primes, for example:
 ///
-///         Buffer 0 removes multiplies of: {  7, 61, 73 }
-///         Buffer 1 removes multiplies of: { 11, 53, 59 }
-///         Buffer 2 removes multiplies of: { 13, 37, 71 }
-///         Buffer 3 removes multiplies of: { 17, 29, 67 }
-///         Buffer 4 removes multiplies of: { 19, 41, 43 }
+///         Buffer 0 removes multiplies of: {  7, 67, 71 }
+///         Buffer 1 removes multiplies of: { 11, 41, 73 }
+///         Buffer 2 removes multiplies of: { 13, 43, 59 }
+///         Buffer 3 removes multiplies of: { 17, 37, 53 }
+///         Buffer 4 removes multiplies of: { 19, 29, 61 }
 ///         Buffer 5 removes multiplies of: { 23, 31, 47 }
 ///         Buffer 6 removes multiplies of: { 79, 97 }
 ///         Buffer 7 removes multiplies of: { 83, 89 }
@@ -150,12 +150,12 @@ const std::array<uint8_t, 7*11*13> buffer_7_11_13 =
 /// Pre-sieve with the primes < 100
 const std::array<std::vector<uint64_t>, 8> bufferPrimes =
 {{
-  {  7, 61, 73 },  // 31 KiB
-  { 11, 53, 59 },  // 34 KiB
-  { 13, 37, 71 },  // 34 KiB
-  { 17, 29, 67 },  // 33 KiB
-  { 19, 41, 43 },  // 33 KiB
-  { 23, 31, 47 },  // 33 KiB
+  {  7, 67, 71 },  // 32 KiB
+  { 11, 41, 73 },  // 32 KiB
+  { 13, 43, 59 },  // 32 KiB
+  { 17, 37, 53 },  // 32 KiB
+  { 19, 29, 61 },  // 32 KiB
+  { 23, 31, 47 },  // 32 KiB
   { 79, 97 },      //  8 KiB
   { 83, 89 }       //  7 KiB
 }};
@@ -258,6 +258,9 @@ void PreSieve::preSieve(uint8_t* sieve,
   uint8_t bit49 = 1 << 4;
   uint8_t bit77 = 1 << 3;
   uint8_t bit91 = 1 << 7;
+  uint8_t bit119 = 1 << 6;
+  uint8_t bit121 = 1 << 7;
+
   size_t i = 0;
 
   if (segmentLow < 30)
@@ -266,6 +269,8 @@ void PreSieve::preSieve(uint8_t* sieve,
     sieve[i++] = 0xff ^ bit49;
   if (segmentLow < 90)
     sieve[i++] = 0xff ^ bit77 ^ bit91;
+  if (segmentLow < 120)
+    sieve[i++] = 0xff ^ bit119 ^ bit121;
 }
 
 /// Pre-sieve with the primes <= 13

--- a/src/PreSieve.cpp
+++ b/src/PreSieve.cpp
@@ -1,15 +1,19 @@
 ///
 /// @file   PreSieve.cpp
-/// @brief  Pre-sieve multiples of small primes <= 59 to speed up the
+/// @brief  Pre-sieve multiples of small primes < 100 to speed up the
 ///         sieve of Eratosthenes. The idea is to allocate several
 ///         arrays (buffers_) and remove the multiples of small primes
 ///         from them at initialization. Each buffer is assigned
 ///         different primes, for example:
 ///
-///         Buffer 0 removes multiplies of:  7, 19, 23, 29
-///         Buffer 1 removes multiplies of: 11, 13, 17, 37
-///         Buffer 2 removes multiplies of: 31, 47, 59
-///         Buffer 3 removes multiplies of: 41, 43, 53
+///         Buffer 0 removes multiplies of: {  7, 61, 73 }
+///         Buffer 1 removes multiplies of: { 11, 53, 59 }
+///         Buffer 2 removes multiplies of: { 13, 37, 71 }
+///         Buffer 3 removes multiplies of: { 17, 29, 67 }
+///         Buffer 4 removes multiplies of: { 19, 41, 43 }
+///         Buffer 5 removes multiplies of: { 23, 31, 47 }
+///         Buffer 6 removes multiplies of: { 79, 97 }
+///         Buffer 7 removes multiplies of: { 83, 89 }
 ///
 ///         Then whilst sieving, we perform a bitwise AND on the
 ///         buffers_ arrays and store the result in the sieve array.
@@ -143,7 +147,7 @@ const std::array<uint8_t, 7*11*13> buffer_7_11_13 =
   0xc7
 };
 
-/// Pre-sieve with the primes <= 97
+/// Pre-sieve with the primes < 100
 const std::array<std::vector<uint64_t>, 8> bufferPrimes =
 {{
   {  7, 61, 73 },  // 31 KiB
@@ -153,7 +157,7 @@ const std::array<std::vector<uint64_t>, 8> bufferPrimes =
   { 19, 41, 43 },  // 33 KiB
   { 23, 31, 47 },  // 33 KiB
   { 79, 97 },      //  8 KiB
-  { 83, 89 },      //  7 KiB
+  { 83, 89 }       //  7 KiB
 }};
 
 void andBuffers(const uint8_t* __restrict buf1,
@@ -248,14 +252,12 @@ void PreSieve::preSieve(uint8_t* sieve,
   else
     preSieveLarge(sieve, sieveSize, segmentLow);
 
-  // Pre-sieving removes the primes <= 59. We
+  // Pre-sieving removes the primes < 100. We
   // have to undo that work and reset these bits
   // to 1 (but 49 = 7 * 7 is not a prime).
   uint8_t bit49 = 1 << 4;
   uint8_t bit77 = 1 << 3;
   uint8_t bit91 = 1 << 7;
-  uint8_t bit119 = 1 << 6;
-  uint8_t bit121 = 1 << 7;
   size_t i = 0;
 
   if (segmentLow < 30)
@@ -264,8 +266,6 @@ void PreSieve::preSieve(uint8_t* sieve,
     sieve[i++] = 0xff ^ bit49;
   if (segmentLow < 90)
     sieve[i++] = 0xff ^ bit77 ^ bit91;
-  if (segmentLow < 120)
-    sieve[i++] = 0xff ^ bit119 ^ bit121;
 }
 
 /// Pre-sieve with the primes <= 13
@@ -296,7 +296,7 @@ void PreSieve::preSieveSmall(uint8_t* sieve,
   }
 }
 
-/// Pre-sieve with the primes <= 59
+/// Pre-sieve with the primes < 100
 void PreSieve::preSieveLarge(uint8_t* sieve,
                              uint64_t sieveSize,
                              uint64_t segmentLow) const

--- a/src/PreSieve.cpp
+++ b/src/PreSieve.cpp
@@ -143,25 +143,34 @@ const std::array<uint8_t, 7*11*13> buffer_7_11_13 =
   0xc7
 };
 
-/// Pre-sieve with the primes <= 59
-const std::array<std::vector<uint64_t>, 4> bufferPrimes =
+/// Pre-sieve with the primes <= 97
+const std::array<std::vector<uint64_t>, 8> bufferPrimes =
 {{
-  {  7, 19, 23, 29 }, // 89 KiB
-  { 11, 13, 17, 37 }, // 90 KiB
-  { 31, 47, 59 },     // 86 KiB
-  { 41, 43, 53 }      // 93 KiB
+  {  7, 61, 73 },  // 31 KiB
+  { 11, 53, 59 },  // 34 KiB
+  { 13, 37, 71 },  // 34 KiB
+  { 17, 29, 67 },  // 33 KiB
+  { 19, 41, 43 },  // 33 KiB
+  { 23, 31, 47 },  // 33 KiB
+  { 79, 97 },      //  8 KiB
+  { 83, 89 },      //  7 KiB
 }};
 
 void andBuffers(const uint8_t* __restrict buf1,
                 const uint8_t* __restrict buf2,
                 const uint8_t* __restrict buf3,
                 const uint8_t* __restrict buf4,
+                const uint8_t* __restrict buf5,
+                const uint8_t* __restrict buf6,
+                const uint8_t* __restrict buf7,
+                const uint8_t* __restrict buf8,
                 uint8_t* __restrict output,
                 size_t bytes)
 {
   // This loop should be auto-vectorized
   for (size_t i = 0; i < bytes; i++)
-    output[i] = buf1[i] & buf2[i] & buf3[i] & buf4[i];
+    output[i] = buf1[i] & buf2[i] & buf3[i] & buf4[i]
+              & buf5[i] & buf6[i] & buf7[i] & buf8[i];
 }
 
 } // namespace
@@ -243,12 +252,20 @@ void PreSieve::preSieve(uint8_t* sieve,
   // have to undo that work and reset these bits
   // to 1 (but 49 = 7 * 7 is not a prime).
   uint8_t bit49 = 1 << 4;
+  uint8_t bit77 = 1 << 3;
+  uint8_t bit91 = 1 << 7;
+  uint8_t bit119 = 1 << 6;
+  uint8_t bit121 = 1 << 7;
   size_t i = 0;
 
   if (segmentLow < 30)
     sieve[i++] = 0xff;
   if (segmentLow < 60)
     sieve[i++] = 0xff ^ bit49;
+  if (segmentLow < 90)
+    sieve[i++] = 0xff ^ bit77 ^ bit91;
+  if (segmentLow < 120)
+    sieve[i++] = 0xff ^ bit119 ^ bit121;
 }
 
 /// Pre-sieve with the primes <= 13
@@ -285,7 +302,7 @@ void PreSieve::preSieveLarge(uint8_t* sieve,
                              uint64_t segmentLow) const
 {
   uint64_t offset = 0;
-  std::array<uint64_t, 4> pos;
+  std::array<uint64_t, 8> pos;
   assert(pos.size() == buffers_.size());
 
   for (size_t i = 0; i < buffers_.size(); i++)
@@ -303,6 +320,10 @@ void PreSieve::preSieveLarge(uint8_t* sieve,
                &buffers_[1][pos[1]],
                &buffers_[2][pos[2]],
                &buffers_[3][pos[3]],
+               &buffers_[4][pos[4]],
+               &buffers_[5][pos[5]],
+               &buffers_[6][pos[6]],
+               &buffers_[7][pos[7]],
                &sieve[offset],
                bytesToCopy);
 


### PR DESCRIPTION
I've been trying to squeeze a bit more performance of out the multi-buffer PreSieve idea, and at the same time reduce the total memory taken by these buffers. Let me know what you think.

**Single-core performance**
`primesieve 1e11 -t1`
| Compiler | -march | Original (seconds) | Modified (seconds) | Improvement | Original (Giga-cycles) | Modified (Giga-cycles) | Improvement
| --- | --- | --- | --- | --- | --- | --- | --- |
clang | skylake | 14.680 | 14.262 | 2.85% | 60.729 | 59.219 | 2.49%
clang | x86-64 | 14.811 | 14.370 | 2.98% | 61.064 | 59.400 | 2.72%
gcc | skylake | 14.800 | 14.588 | 1.43% | 61.541 | 60.700 | 1.37%
gcc | x86-64 | 15.027 | 14.436 | 3.93% | 62.720 | 60.142 | 4.11%

**Multi-core performance**
`primesieve 1e11`
| Compiler | -march | Original (seconds) | Modified (seconds) | Improvement | Original (Giga-cycles) | Modified (Giga-cycles) | Improvement
| --- | --- | --- | --- | --- | --- | --- | --- |
clang | skylake | 4.916 | 4.788 | 2.62% | 134.955 | 131.069 | 2.88%
clang | x86-64 | 4.965 | 4.778 | 3.75% | 134.378 | 130.901 | 2.59%
gcc | skylake | 4.871 | 4.829 | 0.87% | 134.192 | 131.280 | 2.17%
gcc | x86-64 | 4.832 | 4.646 | 3.85% | 134.118 | 130.446 | 2.74%

Each reported value is the average from 5 runs. Each run was preceded by 30 seconds of sleep so that the CPUs can start non-throttled.
