### PR TITLE
Modernise C style <stdint.h> headers to <cstdint> for C++

### DIFF
--- a/examples/cpp/count_primes.cpp
+++ b/examples/cpp/count_primes.cpp
@@ -2,7 +2,7 @@
 /// This example shows how to count primes.
 
 #include <primesieve.hpp>
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 
 int main()

--- a/examples/cpp/nth_prime.cpp
+++ b/examples/cpp/nth_prime.cpp
@@ -2,7 +2,7 @@
 /// Find the nth prime.
 
 #include <primesieve.hpp>
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cstdlib>
 

--- a/include/primesieve.hpp
+++ b/include/primesieve.hpp
@@ -21,7 +21,7 @@
 #include <primesieve/primesieve_error.hpp>
 #include <primesieve/StorePrimes.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 #include <string>
 

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -17,7 +17,7 @@
 #include "config.hpp"
 #include "pmath.hpp"
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 #include <cassert>
 

--- a/include/primesieve/Erat.hpp
+++ b/include/primesieve/Erat.hpp
@@ -18,7 +18,7 @@
 #include "MemoryPool.hpp"
 #include "intrinsics.hpp"
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <memory>
 

--- a/include/primesieve/EratBig.hpp
+++ b/include/primesieve/EratBig.hpp
@@ -15,7 +15,7 @@
 #include "MemoryPool.hpp"
 #include "Wheel.hpp"
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace primesieve {

--- a/include/primesieve/EratMedium.hpp
+++ b/include/primesieve/EratMedium.hpp
@@ -15,7 +15,7 @@
 #include "MemoryPool.hpp"
 #include "Wheel.hpp"
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 
 namespace primesieve {

--- a/include/primesieve/EratSmall.hpp
+++ b/include/primesieve/EratSmall.hpp
@@ -14,7 +14,7 @@
 #include "macros.hpp"
 #include "Wheel.hpp"
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace primesieve {

--- a/include/primesieve/IteratorHelper.hpp
+++ b/include/primesieve/IteratorHelper.hpp
@@ -10,7 +10,7 @@
 #ifndef ITERATOR_HELPER_HPP
 #define ITERATOR_HELPER_HPP
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace primesieve {
 

--- a/include/primesieve/ParallelSieve.hpp
+++ b/include/primesieve/ParallelSieve.hpp
@@ -13,7 +13,7 @@
 #define PARALLELSIEVE_HPP
 
 #include "PrimeSieve.hpp"
-#include <stdint.h>
+#include <cstdint>
 #include <mutex>
 
 namespace primesieve {

--- a/include/primesieve/PreSieve.hpp
+++ b/include/primesieve/PreSieve.hpp
@@ -29,7 +29,7 @@
 #ifndef PRESIEVE_HPP
 #define PRESIEVE_HPP
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <vector>
 

--- a/include/primesieve/PrimeGenerator.hpp
+++ b/include/primesieve/PrimeGenerator.hpp
@@ -19,7 +19,7 @@
 #include "PreSieve.hpp"
 #include "SievingPrimes.hpp"
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace primesieve {

--- a/include/primesieve/PrimeSieve.hpp
+++ b/include/primesieve/PrimeSieve.hpp
@@ -14,7 +14,7 @@
 #define PRIMESIEVE_CLASS_HPP
 
 #include "PreSieve.hpp"
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 
 namespace primesieve {

--- a/include/primesieve/PrintPrimes.hpp
+++ b/include/primesieve/PrintPrimes.hpp
@@ -14,7 +14,7 @@
 #include "macros.hpp"
 #include "PrimeSieve.hpp"
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace primesieve {

--- a/include/primesieve/SievingPrimes.hpp
+++ b/include/primesieve/SievingPrimes.hpp
@@ -13,7 +13,7 @@
 #include "Erat.hpp"
 #include "macros.hpp"
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <vector>
 

--- a/include/primesieve/StorePrimes.hpp
+++ b/include/primesieve/StorePrimes.hpp
@@ -14,7 +14,7 @@
 #include "iterator.hpp"
 #include "primesieve_error.hpp"
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>

--- a/include/primesieve/Wheel.hpp
+++ b/include/primesieve/Wheel.hpp
@@ -12,7 +12,7 @@
 #ifndef WHEEL_HPP
 #define WHEEL_HPP
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <cassert>
 

--- a/include/primesieve/config.hpp
+++ b/include/primesieve/config.hpp
@@ -11,7 +11,7 @@
 #ifndef CONFIG_HPP
 #define CONFIG_HPP
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace {
 namespace config {

--- a/include/primesieve/forward.hpp
+++ b/include/primesieve/forward.hpp
@@ -12,7 +12,7 @@
 #define TYPES_HPP
 
 #include <array>
-#include <stdint.h>
+#include <cstdint>
 
 namespace primesieve {
 

--- a/include/primesieve/intrinsics.hpp
+++ b/include/primesieve/intrinsics.hpp
@@ -11,7 +11,7 @@
 #ifndef INTRINSICS_HPP
 #define INTRINSICS_HPP
 
-#include <stdint.h>
+#include <cstdint>
 #include <cassert>
 
 #if !defined(__has_builtin)

--- a/include/primesieve/iterator.hpp
+++ b/include/primesieve/iterator.hpp
@@ -12,7 +12,7 @@
 #ifndef PRIMESIEVE_ITERATOR_HPP
 #define PRIMESIEVE_ITERATOR_HPP
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 #include <vector>
 #include <memory>

--- a/include/primesieve/littleendian_cast.hpp
+++ b/include/primesieve/littleendian_cast.hpp
@@ -12,7 +12,7 @@
 #ifndef LITTLEENDIAN_CAST_HPP
 #define LITTLEENDIAN_CAST_HPP
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace {
 

--- a/include/primesieve/pmath.hpp
+++ b/include/primesieve/pmath.hpp
@@ -11,7 +11,7 @@
 #ifndef PMATH_HPP
 #define PMATH_HPP
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>

--- a/include/primesieve/resizeUninitialized.hpp
+++ b/include/primesieve/resizeUninitialized.hpp
@@ -13,7 +13,7 @@
 #ifndef RESIZEUNINITIALIZED_HPP
 #define RESIZEUNINITIALIZED_HPP
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 #include <vector>
 

--- a/src/CpuInfo.cpp
+++ b/src/CpuInfo.cpp
@@ -26,7 +26,7 @@
 
 #include <primesieve/CpuInfo.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 #include <exception>
 #include <string>

--- a/src/Erat.cpp
+++ b/src/Erat.cpp
@@ -18,7 +18,7 @@
 #include <primesieve/PreSieve.hpp>
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <algorithm>
 #include <cassert>

--- a/src/EratBig.cpp
+++ b/src/EratBig.cpp
@@ -23,7 +23,7 @@
 #include <primesieve/MemoryPool.hpp>
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cassert>
 #include <algorithm>
 #include <vector>

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -23,7 +23,7 @@
 #include <primesieve/macros.hpp>
 #include <primesieve/MemoryPool.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cassert>
 
 /// This macro sorts the current sieving prime by its

--- a/src/EratSmall.cpp
+++ b/src/EratSmall.cpp
@@ -21,7 +21,7 @@
 #include <primesieve/macros.hpp>
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <cassert>
 #include <vector>

--- a/src/IteratorHelper.cpp
+++ b/src/IteratorHelper.cpp
@@ -14,7 +14,7 @@
 #include <primesieve/PrimeGenerator.hpp>
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <cmath>
 #include <limits>

--- a/src/LookupTables.cpp
+++ b/src/LookupTables.cpp
@@ -13,7 +13,7 @@
 #include <primesieve/Wheel.hpp>
 
 #include <array>
-#include <stdint.h>
+#include <cstdint>
 
 namespace primesieve {
 

--- a/src/ParallelSieve.cpp
+++ b/src/ParallelSieve.cpp
@@ -14,7 +14,7 @@
 #include <primesieve/PrimeSieve.hpp>
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <atomic>
 #include <cassert>

--- a/src/PreSieve.cpp
+++ b/src/PreSieve.cpp
@@ -30,7 +30,7 @@
 #include <primesieve/EratSmall.hpp>
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <array>
 #include <cassert>

--- a/src/PrimeGenerator.cpp
+++ b/src/PrimeGenerator.cpp
@@ -27,7 +27,7 @@
 #include <primesieve/resizeUninitialized.hpp>
 #include <primesieve/SievingPrimes.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <array>
 #include <cassert>

--- a/src/PrimeSieve.cpp
+++ b/src/PrimeSieve.cpp
@@ -17,7 +17,7 @@
 #include <primesieve/PrintPrimes.hpp>
 #include <primesieve/PreSieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <array>
 #include <chrono>

--- a/src/PrintPrimes.cpp
+++ b/src/PrintPrimes.cpp
@@ -19,7 +19,7 @@
 #include <primesieve/Erat.hpp>
 #include <primesieve/SievingPrimes.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <iostream>
 #include <sstream>

--- a/src/SievingPrimes.cpp
+++ b/src/SievingPrimes.cpp
@@ -14,7 +14,7 @@
 #include <primesieve/littleendian_cast.hpp>
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cassert>
 #include <vector>
 

--- a/src/api-c.cpp
+++ b/src/api-c.cpp
@@ -14,7 +14,7 @@
 #include <primesieve.hpp>
 #include <primesieve/malloc_vector.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include <cstddef>
 #include <cerrno>

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -17,7 +17,7 @@
 #include <primesieve/PrimeSieve.hpp>
 #include <primesieve/ParallelSieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 #include <limits>
 #include <string>

--- a/src/app/cmdoptions.cpp
+++ b/src/app/cmdoptions.cpp
@@ -20,7 +20,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <utility>
 

--- a/src/app/cmdoptions.hpp
+++ b/src/app/cmdoptions.hpp
@@ -10,7 +10,7 @@
 #ifndef CMDOPTIONS_HPP
 #define CMDOPTIONS_HPP
 
-#include <stdint.h>
+#include <cstdint>
 #include <deque>
 
 struct CmdOptions

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -11,7 +11,7 @@
 #include <primesieve/ParallelSieve.hpp>
 #include "cmdoptions.hpp"
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <iostream>
 #include <exception>

--- a/src/app/test.cpp
+++ b/src/app/test.cpp
@@ -11,7 +11,7 @@
 #include <primesieve.hpp>
 #include <primesieve/ParallelSieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <cmath>
 #include <cstdlib>

--- a/src/iterator-c.cpp
+++ b/src/iterator-c.cpp
@@ -13,7 +13,7 @@
 #include <primesieve/IteratorHelper.hpp>
 #include <primesieve/PrimeGenerator.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cerrno>
 #include <exception>
 #include <iostream>

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -11,7 +11,7 @@
 #include <primesieve/IteratorHelper.hpp>
 #include <primesieve/PrimeGenerator.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 #include <memory>
 

--- a/src/nthPrime.cpp
+++ b/src/nthPrime.cpp
@@ -13,7 +13,7 @@
 #include <primesieve/pmath.hpp>
 #include <primesieve/primesieve_error.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <cassert>
 #include <chrono>

--- a/src/popcount.cpp
+++ b/src/popcount.cpp
@@ -22,7 +22,7 @@
 
 #include <primesieve/intrinsics.hpp>
 #include <primesieve/forward.hpp>
-#include <stdint.h>
+#include <cstdint>
 
 namespace {
 

--- a/test/calculator.cpp
+++ b/test/calculator.cpp
@@ -14,7 +14,7 @@
 #include <iomanip>
 #include <cstdlib>
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 
 #define STR1(s) #s
 #define TOSTRING(s) STR1(s)

--- a/test/count_primes1.cpp
+++ b/test/count_primes1.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve/ParallelSieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <cmath>
 #include <cstdlib>

--- a/test/count_primes2.cpp
+++ b/test/count_primes2.cpp
@@ -11,7 +11,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <cstdlib>
 #include <cmath>

--- a/test/count_primes3.cpp
+++ b/test/count_primes3.cpp
@@ -11,7 +11,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>

--- a/test/count_quadruplets.cpp
+++ b/test/count_quadruplets.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cstdlib>
 

--- a/test/count_quintuplets.cpp
+++ b/test/count_quintuplets.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cstdlib>
 

--- a/test/count_sextuplets.cpp
+++ b/test/count_sextuplets.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cstdlib>
 

--- a/test/count_triplets.cpp
+++ b/test/count_triplets.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cstdlib>
 

--- a/test/count_twins.cpp
+++ b/test/count_twins.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cstdlib>
 

--- a/test/floorPow2.cpp
+++ b/test/floorPow2.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cmath>
 #include <cstdlib>

--- a/test/generate_n_primes1.cpp
+++ b/test/generate_n_primes1.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cstdlib>
 #include <vector>

--- a/test/generate_primes1.cpp
+++ b/test/generate_primes1.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cstdlib>
 #include <vector>

--- a/test/ilog2.cpp
+++ b/test/ilog2.cpp
@@ -12,7 +12,7 @@
 
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cmath>
 #include <cstdlib>

--- a/test/isqrt.cpp
+++ b/test/isqrt.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cmath>
 #include <cstdlib>

--- a/test/isqrt_constexpr.cpp
+++ b/test/isqrt_constexpr.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <limits>
 #include <iostream>
 

--- a/test/next_prime1.cpp
+++ b/test/next_prime1.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include <exception>
 #include <iostream>

--- a/test/nth_prime1.cpp
+++ b/test/nth_prime1.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <vector>
 #include <cstdlib>

--- a/test/nth_prime2.cpp
+++ b/test/nth_prime2.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <exception>
 #include <cstdlib>

--- a/test/nth_prime3.cpp
+++ b/test/nth_prime3.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <cstdlib>
 

--- a/test/number_of_bits.cpp
+++ b/test/number_of_bits.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve/pmath.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 
 void check(bool OK)

--- a/test/prev_prime1.cpp
+++ b/test/prev_prime1.cpp
@@ -10,7 +10,7 @@
 
 #include <primesieve.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include <exception>
 #include <iostream>

--- a/test/resizeUninitialized.cpp
+++ b/test/resizeUninitialized.cpp
@@ -11,7 +11,7 @@
 
 #include <primesieve/resizeUninitialized.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <vector>
 #include <cstdlib>


### PR DESCRIPTION
Motives:
 [Clang Tidy](https://clang.llvm.org/extra//clang-tidy/checks/modernize-deprecated-headers.html)
 [Stackoverflow answer regarding \<cstdint\> vs \<stdint.h\>](https://stackoverflow.com/a/13643019)

C API is not affected by this commit.
100% tests passed, 0 tests failed out of 28=  37.93 sec

Thank you for considering these changes.