### PR TITLE
Get rid of pointer comparisons using operator `<`

### DIFF
--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -102,6 +102,7 @@ public:
   void setEnd(SievingPrime* end) { end_ = end; }
   void reset() { end_ = begin(); }
   bool empty() { return begin() == end(); }
+  std::size_t size() { return (std::size_t) (end() - begin()); }
 
   /// Get the sieving prime's bucket.
   /// For performance reasons we don't keep an array with all

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -116,12 +116,12 @@ public:
   static Bucket* get(SievingPrime* sievingPrime)
   {
     ASSERT(sievingPrime != nullptr);
-    std::size_t address = (std::size_t) sievingPrime;
+    uintptr_t address = (uintptr_t) (void*) sievingPrime;
     // We need to adjust the address
     // in case the bucket is full.
     address -= 1;
     address -= address % sizeof(Bucket);
-    return (Bucket*) address;
+    return (Bucket*) (void*) address;
   }
 
   /// Returns true if the bucket is full with sieving primes
@@ -133,7 +133,7 @@ public:
   ///
   static bool isFull(SievingPrime* sievingPrime)
   {
-    std::size_t address = (std::size_t) sievingPrime;
+    uintptr_t address = (uintptr_t) (void*) sievingPrime;
     return address % sizeof(Bucket) == 0;
   }
 

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -39,24 +39,24 @@ public:
 
   SievingPrime() = default;
 
-  SievingPrime(uint64_t sievingPrime,
-               uint64_t multipleIndex,
-               uint64_t wheelIndex)
+  SievingPrime(std::size_t sievingPrime,
+               std::size_t multipleIndex,
+               std::size_t wheelIndex)
   {
     set(sievingPrime, multipleIndex, wheelIndex);
   }
 
-  void set(uint64_t multipleIndex,
-           uint64_t wheelIndex)
+  void set(std::size_t multipleIndex,
+           std::size_t wheelIndex)
   {
     ASSERT(multipleIndex <= MAX_MULTIPLEINDEX);
     ASSERT(wheelIndex <= MAX_WHEELINDEX);
     indexes_ = (uint32_t) (multipleIndex | (wheelIndex << 23));
   }
 
-  void set(uint64_t sievingPrime,
-           uint64_t multipleIndex,
-           uint64_t wheelIndex)
+  void set(std::size_t sievingPrime,
+           std::size_t multipleIndex,
+           std::size_t wheelIndex)
   {
     ASSERT(multipleIndex <= MAX_MULTIPLEINDEX);
     ASSERT(wheelIndex <= MAX_WHEELINDEX);
@@ -64,17 +64,17 @@ public:
     sievingPrime_ = (uint32_t) sievingPrime;
   }
 
-  uint64_t getSievingPrime() const
+  std::size_t getSievingPrime() const
   {
     return sievingPrime_;
   }
 
-  uint64_t getMultipleIndex() const
+  std::size_t getMultipleIndex() const
   {
     return indexes_ & MAX_MULTIPLEINDEX;
   }
 
-  uint64_t getWheelIndex() const
+  std::size_t getWheelIndex() const
   {
     return indexes_ >> 23;
   }

--- a/include/primesieve/Bucket.hpp
+++ b/include/primesieve/Bucket.hpp
@@ -102,7 +102,6 @@ public:
   void setEnd(SievingPrime* end) { end_ = end; }
   void reset() { end_ = begin(); }
   bool empty() { return begin() == end(); }
-  std::size_t size() { return (std::size_t) (end() - begin()); }
 
   /// Get the sieving prime's bucket.
   /// For performance reasons we don't keep an array with all

--- a/include/primesieve/EratBig.hpp
+++ b/include/primesieve/EratBig.hpp
@@ -38,7 +38,7 @@ private:
   MemoryPool* memoryPool_ = nullptr;
   pod_vector<SievingPrime*> buckets_;
   void storeSievingPrime(uint64_t, uint64_t, uint64_t);
-  NOINLINE void crossOff(uint8_t* sieve, SievingPrime* prime, std::size_t size);
+  NOINLINE void crossOff(uint8_t* sieve, SievingPrime* prime, SievingPrime* end);
 };
 
 } // namespace

--- a/include/primesieve/EratBig.hpp
+++ b/include/primesieve/EratBig.hpp
@@ -38,8 +38,7 @@ private:
   MemoryPool* memoryPool_ = nullptr;
   pod_vector<SievingPrime*> buckets_;
   void storeSievingPrime(uint64_t, uint64_t, uint64_t);
-  NOINLINE void crossOff_1(uint8_t* sieve, SievingPrime* prime, SievingPrime* end);
-  NOINLINE void crossOff_2(uint8_t* sieve, SievingPrime* prime, SievingPrime* end);
+  NOINLINE void crossOff(uint8_t* sieve, SievingPrime* prime, std::size_t size);
 };
 
 } // namespace

--- a/include/primesieve/EratBig.hpp
+++ b/include/primesieve/EratBig.hpp
@@ -38,7 +38,8 @@ private:
   MemoryPool* memoryPool_ = nullptr;
   pod_vector<SievingPrime*> buckets_;
   void storeSievingPrime(uint64_t, uint64_t, uint64_t);
-  NOINLINE void crossOff(uint8_t* sieve, Bucket*);
+  NOINLINE void crossOff_1(uint8_t* sieve, SievingPrime* prime, SievingPrime* end);
+  NOINLINE void crossOff_2(uint8_t* sieve, SievingPrime* prime, SievingPrime* end);
 };
 
 } // namespace

--- a/include/primesieve/EratMedium.hpp
+++ b/include/primesieve/EratMedium.hpp
@@ -37,14 +37,14 @@ private:
   pod_vector<SievingPrime*> buckets_;
   pod_vector<SievingPrime*> currentBuckets_;
   void storeSievingPrime(uint64_t, uint64_t, uint64_t);
-  NOINLINE void crossOff_7(uint8_t*, uint8_t*, Bucket*);
-  NOINLINE void crossOff_11(uint8_t*, uint8_t*, Bucket*);
-  NOINLINE void crossOff_13(uint8_t*, uint8_t*, Bucket*);
-  NOINLINE void crossOff_17(uint8_t*, uint8_t*, Bucket*);
-  NOINLINE void crossOff_19(uint8_t*, uint8_t*, Bucket*);
-  NOINLINE void crossOff_23(uint8_t*, uint8_t*, Bucket*);
-  NOINLINE void crossOff_29(uint8_t*, uint8_t*, Bucket*);
-  NOINLINE void crossOff_31(uint8_t*, uint8_t*, Bucket*);
+  NOINLINE void crossOff_7(uint8_t*, std::size_t, Bucket*);
+  NOINLINE void crossOff_11(uint8_t*, std::size_t, Bucket*);
+  NOINLINE void crossOff_13(uint8_t*, std::size_t, Bucket*);
+  NOINLINE void crossOff_17(uint8_t*, std::size_t, Bucket*);
+  NOINLINE void crossOff_19(uint8_t*, std::size_t, Bucket*);
+  NOINLINE void crossOff_23(uint8_t*, std::size_t, Bucket*);
+  NOINLINE void crossOff_29(uint8_t*, std::size_t, Bucket*);
+  NOINLINE void crossOff_31(uint8_t*, std::size_t, Bucket*);
 };
 
 } // namespace

--- a/include/primesieve/EratSmall.hpp
+++ b/include/primesieve/EratSmall.hpp
@@ -35,7 +35,7 @@ private:
   std::size_t l1CacheSize_ = 0;
   pod_vector<SievingPrime> primes_;
   void storeSievingPrime(uint64_t, uint64_t, uint64_t);
-  NOINLINE void crossOff(uint8_t*, uint8_t*);
+  NOINLINE void crossOff(uint8_t*, std::size_t);
 };
 
 } // namespace

--- a/include/primesieve/config.hpp
+++ b/include/primesieve/config.hpp
@@ -86,7 +86,7 @@ constexpr uint64_t MIN_THREAD_DISTANCE = (uint64_t) 1e7;
 ///
 /// @pre FACTOR_ERATSMALL >= 0 && <= 4.5
 ///
-constexpr double FACTOR_ERATSMALL = 0.2;
+constexpr double FACTOR_ERATSMALL = 0.25;
 
 /// Sieving primes > (sieveSize in bytes * FACTOR_ERATSMALL)
 /// and <= (sieveSize in bytes * FACTOR_ERATMEDIUM)

--- a/src/EratBig.cpp
+++ b/src/EratBig.cpp
@@ -229,7 +229,7 @@ void EratBig::crossOff(uint8_t* sieve,
   std::size_t moduloSieveSize = moduloSieveSize_;
   std::size_t log2SieveSize = log2SieveSize_;
   std::size_t size = (std::size_t) (end - prime);
-  SievingPrime* end2 = prime + size - size % 2;
+  SievingPrime* end2 = end - size % 2;
 
   // Process 2 sieving primes per loop iteration to
   // increase instruction level parallelism.

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -25,22 +25,6 @@
 
 #include <stdint.h>
 
-/// This macro sorts the current sieving prime by its
-/// wheelIndex after sieving has finished. When we then
-/// iterate over the sieving primes in the next segment the
-/// 'switch (wheelIndex)' branch will be predicted
-/// correctly by the CPU.
-///
-#define CHECK_FINISHED(wheelIndex) \
-  if_unlikely(i >= sieveSize) \
-  { \
-    auto multipleIndex = i - sieveSize; \
-    if (Bucket::isFull(buckets_[wheelIndex])) \
-      memoryPool.addBucket(buckets_[wheelIndex]); \
-    buckets_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex); \
-    break; \
-  }
-
 namespace primesieve {
 
 /// @stop:      Upper bound for sieving
@@ -125,13 +109,30 @@ void EratMedium::crossOff(pod_vector<uint8_t>& sieve)
   }
 }
 
+/// This macro sorts the current sieving prime by its
+/// wheelIndex after sieving has finished. When we then
+/// iterate over the sieving primes in the next segment the
+/// 'switch (wheelIndex)' branch will be predicted
+/// correctly by the CPU.
+///
+#define CHECK_FINISHED(wheelIndex) \
+  if_unlikely(i >= sieveSize) \
+  { \
+    i -= sieveSize; \
+    if (Bucket::isFull(buckets[wheelIndex])) \
+      memoryPool.addBucket(buckets[wheelIndex]); \
+    buckets[wheelIndex]++->set(sievingPrime, i, wheelIndex); \
+    break; \
+  }
+
 /// For sieving primes of type n % 30 == 7
 void EratMedium::crossOff_7(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
+  auto buckets = buckets_.data();
+  MemoryPool& memoryPool = *memoryPool_;
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
   std::size_t wheelIndex = prime->getWheelIndex();
-  MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
@@ -164,10 +165,11 @@ void EratMedium::crossOff_7(uint8_t* sieve, std::size_t sieveSize, Bucket* bucke
 /// For sieving primes of type n % 30 == 11
 void EratMedium::crossOff_11(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
+  auto buckets = buckets_.data();
+  MemoryPool& memoryPool = *memoryPool_;
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
   std::size_t wheelIndex = prime->getWheelIndex();
-  MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
@@ -201,10 +203,11 @@ void EratMedium::crossOff_11(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 /// For sieving primes of type n % 30 == 13
 void EratMedium::crossOff_13(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
+  auto buckets = buckets_.data();
+  MemoryPool& memoryPool = *memoryPool_;
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
   std::size_t wheelIndex = prime->getWheelIndex();
-  MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
@@ -238,10 +241,11 @@ void EratMedium::crossOff_13(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 /// For sieving primes of type n % 30 == 17
 void EratMedium::crossOff_17(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
+  auto buckets = buckets_.data();
+  MemoryPool& memoryPool = *memoryPool_;
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
   std::size_t wheelIndex = prime->getWheelIndex();
-  MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
@@ -275,10 +279,11 @@ void EratMedium::crossOff_17(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 /// For sieving primes of type n % 30 == 19
 void EratMedium::crossOff_19(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
+  auto buckets = buckets_.data();
+  MemoryPool& memoryPool = *memoryPool_;
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
   std::size_t wheelIndex = prime->getWheelIndex();
-  MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
@@ -312,10 +317,11 @@ void EratMedium::crossOff_19(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 /// For sieving primes of type n % 30 == 23
 void EratMedium::crossOff_23(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
+  auto buckets = buckets_.data();
+  MemoryPool& memoryPool = *memoryPool_;
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
   std::size_t wheelIndex = prime->getWheelIndex();
-  MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
@@ -348,10 +354,11 @@ void EratMedium::crossOff_23(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 /// For sieving primes of type n % 30 == 29
 void EratMedium::crossOff_29(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
+  auto buckets = buckets_.data();
+  MemoryPool& memoryPool = *memoryPool_;
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
   std::size_t wheelIndex = prime->getWheelIndex();
-  MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
@@ -384,10 +391,11 @@ void EratMedium::crossOff_29(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 /// For sieving primes of type n % 30 == 1
 void EratMedium::crossOff_31(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
+  auto buckets = buckets_.data();
+  MemoryPool& memoryPool = *memoryPool_;
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
   std::size_t wheelIndex = prime->getWheelIndex();
-  MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -62,10 +62,10 @@ void EratMedium::init(uint64_t stop,
 /// Add a new sieving prime to EratMedium
 void EratMedium::storeSievingPrime(uint64_t prime,
                                    uint64_t multipleIndex,
-                                   uint64_t wheelIndex)
+                                   std::size_t wheelIndex)
 {
   ASSERT(prime <= maxPrime_);
-  uint64_t sievingPrime = prime / 30;
+  std::size_t sievingPrime = prime / 30;
 
   if_unlikely(buckets_.empty())
   {
@@ -97,7 +97,7 @@ void EratMedium::crossOff(pod_vector<uint8_t>& sieve)
       Bucket* bucket = Bucket::get(currentBuckets_[i]);
       bucket->setEnd(currentBuckets_[i]);
       currentBuckets_[i] = nullptr;
-      uint64_t wheelIndex = i;
+      std::size_t wheelIndex = i;
 
       // Iterate over the current bucket list.
       // For each bucket cross off the
@@ -130,17 +130,17 @@ void EratMedium::crossOff_7(uint8_t* sieve, std::size_t sieveSize, Bucket* bucke
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
-  uint64_t wheelIndex = prime->getWheelIndex();
+  std::size_t wheelIndex = prime->getWheelIndex();
   MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
-    uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t i = prime->getMultipleIndex();
-    uint64_t dist0 = sievingPrime * 6 + 1;
-    uint64_t dist1 = sievingPrime * 4 + 1;
-    uint64_t dist2 = sievingPrime * 2 + 0;
-    uint64_t dist4 = sievingPrime * 2 + 1;
+    std::size_t sievingPrime = prime->getSievingPrime();
+    std::size_t i = prime->getMultipleIndex();
+    std::size_t dist0 = sievingPrime * 6 + 1;
+    std::size_t dist1 = sievingPrime * 4 + 1;
+    std::size_t dist2 = sievingPrime * 2 + 0;
+    std::size_t dist4 = sievingPrime * 2 + 1;
 
     switch (wheelIndex)
     {
@@ -166,18 +166,18 @@ void EratMedium::crossOff_11(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
-  uint64_t wheelIndex = prime->getWheelIndex();
+  std::size_t wheelIndex = prime->getWheelIndex();
   MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
-    uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t i = prime->getMultipleIndex();
-    uint64_t dist0 = sievingPrime * 6 + 2;
-    uint64_t dist1 = sievingPrime * 4 + 1;
-    uint64_t dist2 = sievingPrime * 2 + 1;
-    uint64_t dist3 = sievingPrime * 4 + 2;
-    uint64_t dist4 = sievingPrime * 2 + 0;
+    std::size_t sievingPrime = prime->getSievingPrime();
+    std::size_t i = prime->getMultipleIndex();
+    std::size_t dist0 = sievingPrime * 6 + 2;
+    std::size_t dist1 = sievingPrime * 4 + 1;
+    std::size_t dist2 = sievingPrime * 2 + 1;
+    std::size_t dist3 = sievingPrime * 4 + 2;
+    std::size_t dist4 = sievingPrime * 2 + 0;
 
     switch (wheelIndex)
     {
@@ -203,18 +203,18 @@ void EratMedium::crossOff_13(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
-  uint64_t wheelIndex = prime->getWheelIndex();
+  std::size_t wheelIndex = prime->getWheelIndex();
   MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
-    uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t i = prime->getMultipleIndex();
-    uint64_t dist0 = sievingPrime * 6 + 2;
-    uint64_t dist1 = sievingPrime * 4 + 2;
-    uint64_t dist2 = sievingPrime * 2 + 1;
-    uint64_t dist5 = sievingPrime * 4 + 1;
-    uint64_t dist6 = sievingPrime * 6 + 3;
+    std::size_t sievingPrime = prime->getSievingPrime();
+    std::size_t i = prime->getMultipleIndex();
+    std::size_t dist0 = sievingPrime * 6 + 2;
+    std::size_t dist1 = sievingPrime * 4 + 2;
+    std::size_t dist2 = sievingPrime * 2 + 1;
+    std::size_t dist5 = sievingPrime * 4 + 1;
+    std::size_t dist6 = sievingPrime * 6 + 3;
 
     switch (wheelIndex)
     {
@@ -240,18 +240,18 @@ void EratMedium::crossOff_17(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
-  uint64_t wheelIndex = prime->getWheelIndex();
+  std::size_t wheelIndex = prime->getWheelIndex();
   MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
-    uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t i = prime->getMultipleIndex();
-    uint64_t dist0 = sievingPrime * 6 + 3;
-    uint64_t dist1 = sievingPrime * 4 + 3;
-    uint64_t dist2 = sievingPrime * 2 + 1;
-    uint64_t dist3 = sievingPrime * 4 + 2;
-    uint64_t dist6 = sievingPrime * 6 + 4;
+    std::size_t sievingPrime = prime->getSievingPrime();
+    std::size_t i = prime->getMultipleIndex();
+    std::size_t dist0 = sievingPrime * 6 + 3;
+    std::size_t dist1 = sievingPrime * 4 + 3;
+    std::size_t dist2 = sievingPrime * 2 + 1;
+    std::size_t dist3 = sievingPrime * 4 + 2;
+    std::size_t dist6 = sievingPrime * 6 + 4;
 
     switch (wheelIndex)
     {
@@ -277,18 +277,18 @@ void EratMedium::crossOff_19(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
-  uint64_t wheelIndex = prime->getWheelIndex();
+  std::size_t wheelIndex = prime->getWheelIndex();
   MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
-    uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t i = prime->getMultipleIndex();
-    uint64_t dist0 = sievingPrime * 6 + 4;
-    uint64_t dist1 = sievingPrime * 4 + 2;
-    uint64_t dist2 = sievingPrime * 2 + 2;
-    uint64_t dist4 = sievingPrime * 2 + 1;
-    uint64_t dist5 = sievingPrime * 4 + 3;
+    std::size_t sievingPrime = prime->getSievingPrime();
+    std::size_t i = prime->getMultipleIndex();
+    std::size_t dist0 = sievingPrime * 6 + 4;
+    std::size_t dist1 = sievingPrime * 4 + 2;
+    std::size_t dist2 = sievingPrime * 2 + 2;
+    std::size_t dist4 = sievingPrime * 2 + 1;
+    std::size_t dist5 = sievingPrime * 4 + 3;
 
     switch (wheelIndex)
     {
@@ -314,17 +314,17 @@ void EratMedium::crossOff_23(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
-  uint64_t wheelIndex = prime->getWheelIndex();
+  std::size_t wheelIndex = prime->getWheelIndex();
   MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
-    uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t i = prime->getMultipleIndex();
-    uint64_t dist0 = sievingPrime * 6 + 5;
-    uint64_t dist1 = sievingPrime * 4 + 3;
-    uint64_t dist2 = sievingPrime * 2 + 1;
-    uint64_t dist4 = sievingPrime * 2 + 2;
+    std::size_t sievingPrime = prime->getSievingPrime();
+    std::size_t i = prime->getMultipleIndex();
+    std::size_t dist0 = sievingPrime * 6 + 5;
+    std::size_t dist1 = sievingPrime * 4 + 3;
+    std::size_t dist2 = sievingPrime * 2 + 1;
+    std::size_t dist4 = sievingPrime * 2 + 2;
 
     switch (wheelIndex)
     {
@@ -350,17 +350,17 @@ void EratMedium::crossOff_29(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
-  uint64_t wheelIndex = prime->getWheelIndex();
+  std::size_t wheelIndex = prime->getWheelIndex();
   MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
-    uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t i = prime->getMultipleIndex();
-    uint64_t dist0 = sievingPrime * 6 + 6;
-    uint64_t dist1 = sievingPrime * 4 + 4;
-    uint64_t dist2 = sievingPrime * 2 + 2;
-    uint64_t dist6 = sievingPrime * 6 + 5;
+    std::size_t sievingPrime = prime->getSievingPrime();
+    std::size_t i = prime->getMultipleIndex();
+    std::size_t dist0 = sievingPrime * 6 + 6;
+    std::size_t dist1 = sievingPrime * 4 + 4;
+    std::size_t dist2 = sievingPrime * 2 + 2;
+    std::size_t dist6 = sievingPrime * 6 + 5;
 
     switch (wheelIndex)
     {
@@ -386,17 +386,17 @@ void EratMedium::crossOff_31(uint8_t* sieve, std::size_t sieveSize, Bucket* buck
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
-  uint64_t wheelIndex = prime->getWheelIndex();
+  std::size_t wheelIndex = prime->getWheelIndex();
   MemoryPool& memoryPool = *memoryPool_;
 
   for (; prime != end; prime++)
   {
-    uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t i = prime->getMultipleIndex();
-    uint64_t dist0 = sievingPrime * 6 + 1;
-    uint64_t dist1 = sievingPrime * 4 + 0;
-    uint64_t dist2 = sievingPrime * 2 + 0;
-    uint64_t dist6 = sievingPrime * 6 + 0;
+    std::size_t sievingPrime = prime->getSievingPrime();
+    std::size_t i = prime->getMultipleIndex();
+    std::size_t dist0 = sievingPrime * 6 + 1;
+    std::size_t dist1 = sievingPrime * 4 + 0;
+    std::size_t dist2 = sievingPrime * 2 + 0;
+    std::size_t dist6 = sievingPrime * 6 + 0;
 
     switch (wheelIndex)
     {

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -90,7 +90,7 @@ void EratMedium::crossOff(pod_vector<uint8_t>& sieve)
   // The 2nd list contains sieving primes with wheelIndex = 1.
   // The 3rd list contains sieving primes with wheelIndex = 2.
   // ...
-  for (uint64_t i = 0; i < 64; i++)
+  for (std::size_t i = 0; i < 64; i++)
   {
     if (currentBuckets_[i])
     {

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -62,10 +62,10 @@ void EratMedium::init(uint64_t stop,
 /// Add a new sieving prime to EratMedium
 void EratMedium::storeSievingPrime(uint64_t prime,
                                    uint64_t multipleIndex,
-                                   std::size_t wheelIndex)
+                                   uint64_t wheelIndex)
 {
   ASSERT(prime <= maxPrime_);
-  std::size_t sievingPrime = prime / 30;
+  uint64_t sievingPrime = prime / 30;
 
   if_unlikely(buckets_.empty())
   {

--- a/src/EratMedium.cpp
+++ b/src/EratMedium.cpp
@@ -32,9 +32,9 @@
 /// correctly by the CPU.
 ///
 #define CHECK_FINISHED(wheelIndex) \
-  if_unlikely(p >= sieveEnd) \
+  if_unlikely(i >= sieveSize) \
   { \
-    multipleIndex = (uint64_t) (p - sieveEnd); \
+    auto multipleIndex = i - sieveSize; \
     if (Bucket::isFull(buckets_[wheelIndex])) \
       memoryPool.addBucket(buckets_[wheelIndex]); \
     buckets_[wheelIndex]++->set(sievingPrime, multipleIndex, wheelIndex); \
@@ -106,14 +106,14 @@ void EratMedium::crossOff(pod_vector<uint8_t>& sieve)
       {
         switch (wheelIndex / 8)
         {
-          case 0: crossOff_7 (sieve.begin(), sieve.end(), bucket); break;
-          case 1: crossOff_11(sieve.begin(), sieve.end(), bucket); break;
-          case 2: crossOff_13(sieve.begin(), sieve.end(), bucket); break;
-          case 3: crossOff_17(sieve.begin(), sieve.end(), bucket); break;
-          case 4: crossOff_19(sieve.begin(), sieve.end(), bucket); break;
-          case 5: crossOff_23(sieve.begin(), sieve.end(), bucket); break;
-          case 6: crossOff_29(sieve.begin(), sieve.end(), bucket); break;
-          case 7: crossOff_31(sieve.begin(), sieve.end(), bucket); break;
+          case 0: crossOff_7 (sieve.data(), sieve.size(), bucket); break;
+          case 1: crossOff_11(sieve.data(), sieve.size(), bucket); break;
+          case 2: crossOff_13(sieve.data(), sieve.size(), bucket); break;
+          case 3: crossOff_17(sieve.data(), sieve.size(), bucket); break;
+          case 4: crossOff_19(sieve.data(), sieve.size(), bucket); break;
+          case 5: crossOff_23(sieve.data(), sieve.size(), bucket); break;
+          case 6: crossOff_29(sieve.data(), sieve.size(), bucket); break;
+          case 7: crossOff_31(sieve.data(), sieve.size(), bucket); break;
           default: UNREACHABLE;
         }
 
@@ -126,7 +126,7 @@ void EratMedium::crossOff(pod_vector<uint8_t>& sieve)
 }
 
 /// For sieving primes of type n % 30 == 7
-void EratMedium::crossOff_7(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
+void EratMedium::crossOff_7(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
@@ -136,8 +136,7 @@ void EratMedium::crossOff_7(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
   for (; prime != end; prime++)
   {
     uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t multipleIndex = prime->getMultipleIndex();
-    uint8_t* p = sieve + multipleIndex;
+    uint64_t i = prime->getMultipleIndex();
     uint64_t dist0 = sievingPrime * 6 + 1;
     uint64_t dist1 = sievingPrime * 4 + 1;
     uint64_t dist2 = sievingPrime * 2 + 0;
@@ -149,21 +148,21 @@ void EratMedium::crossOff_7(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
 
       for (;;)
       {
-        case 0: CHECK_FINISHED(0); *p &= BIT0; p += dist0; FALLTHROUGH;
-        case 1: CHECK_FINISHED(1); *p &= BIT4; p += dist1; FALLTHROUGH;
-        case 2: CHECK_FINISHED(2); *p &= BIT3; p += dist2; FALLTHROUGH;
-        case 3: CHECK_FINISHED(3); *p &= BIT7; p += dist1; FALLTHROUGH;
-        case 4: CHECK_FINISHED(4); *p &= BIT6; p += dist4; FALLTHROUGH;
-        case 5: CHECK_FINISHED(5); *p &= BIT2; p += dist1; FALLTHROUGH;
-        case 6: CHECK_FINISHED(6); *p &= BIT1; p += dist0; FALLTHROUGH;
-        case 7: CHECK_FINISHED(7); *p &= BIT5; p += dist4;
+        case 0: CHECK_FINISHED(0); sieve[i] &= BIT0; i += dist0; FALLTHROUGH;
+        case 1: CHECK_FINISHED(1); sieve[i] &= BIT4; i += dist1; FALLTHROUGH;
+        case 2: CHECK_FINISHED(2); sieve[i] &= BIT3; i += dist2; FALLTHROUGH;
+        case 3: CHECK_FINISHED(3); sieve[i] &= BIT7; i += dist1; FALLTHROUGH;
+        case 4: CHECK_FINISHED(4); sieve[i] &= BIT6; i += dist4; FALLTHROUGH;
+        case 5: CHECK_FINISHED(5); sieve[i] &= BIT2; i += dist1; FALLTHROUGH;
+        case 6: CHECK_FINISHED(6); sieve[i] &= BIT1; i += dist0; FALLTHROUGH;
+        case 7: CHECK_FINISHED(7); sieve[i] &= BIT5; i += dist4;
       }
     }
   }
 }
 
 /// For sieving primes of type n % 30 == 11
-void EratMedium::crossOff_11(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
+void EratMedium::crossOff_11(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
@@ -173,8 +172,7 @@ void EratMedium::crossOff_11(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
   for (; prime != end; prime++)
   {
     uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t multipleIndex = prime->getMultipleIndex();
-    uint8_t* p = sieve + multipleIndex;
+    uint64_t i = prime->getMultipleIndex();
     uint64_t dist0 = sievingPrime * 6 + 2;
     uint64_t dist1 = sievingPrime * 4 + 1;
     uint64_t dist2 = sievingPrime * 2 + 1;
@@ -187,21 +185,21 @@ void EratMedium::crossOff_11(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
 
       for (;;)
       {
-        case  8: CHECK_FINISHED( 8); *p &= BIT1; p += dist0; FALLTHROUGH;
-        case  9: CHECK_FINISHED( 9); *p &= BIT3; p += dist1; FALLTHROUGH;
-        case 10: CHECK_FINISHED(10); *p &= BIT7; p += dist2; FALLTHROUGH;
-        case 11: CHECK_FINISHED(11); *p &= BIT5; p += dist3; FALLTHROUGH;
-        case 12: CHECK_FINISHED(12); *p &= BIT0; p += dist4; FALLTHROUGH;
-        case 13: CHECK_FINISHED(13); *p &= BIT6; p += dist3; FALLTHROUGH;
-        case 14: CHECK_FINISHED(14); *p &= BIT2; p += dist0; FALLTHROUGH;
-        case 15: CHECK_FINISHED(15); *p &= BIT4; p += dist2;
+        case  8: CHECK_FINISHED( 8); sieve[i] &= BIT1; i += dist0; FALLTHROUGH;
+        case  9: CHECK_FINISHED( 9); sieve[i] &= BIT3; i += dist1; FALLTHROUGH;
+        case 10: CHECK_FINISHED(10); sieve[i] &= BIT7; i += dist2; FALLTHROUGH;
+        case 11: CHECK_FINISHED(11); sieve[i] &= BIT5; i += dist3; FALLTHROUGH;
+        case 12: CHECK_FINISHED(12); sieve[i] &= BIT0; i += dist4; FALLTHROUGH;
+        case 13: CHECK_FINISHED(13); sieve[i] &= BIT6; i += dist3; FALLTHROUGH;
+        case 14: CHECK_FINISHED(14); sieve[i] &= BIT2; i += dist0; FALLTHROUGH;
+        case 15: CHECK_FINISHED(15); sieve[i] &= BIT4; i += dist2;
       }
     }
   }
 }
 
 /// For sieving primes of type n % 30 == 13
-void EratMedium::crossOff_13(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
+void EratMedium::crossOff_13(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
@@ -211,8 +209,7 @@ void EratMedium::crossOff_13(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
   for (; prime != end; prime++)
   {
     uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t multipleIndex = prime->getMultipleIndex();
-    uint8_t* p = sieve + multipleIndex;
+    uint64_t i = prime->getMultipleIndex();
     uint64_t dist0 = sievingPrime * 6 + 2;
     uint64_t dist1 = sievingPrime * 4 + 2;
     uint64_t dist2 = sievingPrime * 2 + 1;
@@ -225,21 +222,21 @@ void EratMedium::crossOff_13(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
 
       for (;;)
       {
-        case 16: CHECK_FINISHED(16); *p &= BIT2; p += dist0; FALLTHROUGH;
-        case 17: CHECK_FINISHED(17); *p &= BIT7; p += dist1; FALLTHROUGH;
-        case 18: CHECK_FINISHED(18); *p &= BIT5; p += dist2; FALLTHROUGH;
-        case 19: CHECK_FINISHED(19); *p &= BIT4; p += dist1; FALLTHROUGH;
-        case 20: CHECK_FINISHED(20); *p &= BIT1; p += dist2; FALLTHROUGH;
-        case 21: CHECK_FINISHED(21); *p &= BIT0; p += dist5; FALLTHROUGH;
-        case 22: CHECK_FINISHED(22); *p &= BIT6; p += dist6; FALLTHROUGH;
-        case 23: CHECK_FINISHED(23); *p &= BIT3; p += dist2;
+        case 16: CHECK_FINISHED(16); sieve[i] &= BIT2; i += dist0; FALLTHROUGH;
+        case 17: CHECK_FINISHED(17); sieve[i] &= BIT7; i += dist1; FALLTHROUGH;
+        case 18: CHECK_FINISHED(18); sieve[i] &= BIT5; i += dist2; FALLTHROUGH;
+        case 19: CHECK_FINISHED(19); sieve[i] &= BIT4; i += dist1; FALLTHROUGH;
+        case 20: CHECK_FINISHED(20); sieve[i] &= BIT1; i += dist2; FALLTHROUGH;
+        case 21: CHECK_FINISHED(21); sieve[i] &= BIT0; i += dist5; FALLTHROUGH;
+        case 22: CHECK_FINISHED(22); sieve[i] &= BIT6; i += dist6; FALLTHROUGH;
+        case 23: CHECK_FINISHED(23); sieve[i] &= BIT3; i += dist2;
       }
     }
   }
 }
 
 /// For sieving primes of type n % 30 == 17
-void EratMedium::crossOff_17(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
+void EratMedium::crossOff_17(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
@@ -249,8 +246,7 @@ void EratMedium::crossOff_17(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
   for (; prime != end; prime++)
   {
     uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t multipleIndex = prime->getMultipleIndex();
-    uint8_t* p = sieve + multipleIndex;
+    uint64_t i = prime->getMultipleIndex();
     uint64_t dist0 = sievingPrime * 6 + 3;
     uint64_t dist1 = sievingPrime * 4 + 3;
     uint64_t dist2 = sievingPrime * 2 + 1;
@@ -263,21 +259,21 @@ void EratMedium::crossOff_17(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
 
       for (;;)
       {
-        case 24: CHECK_FINISHED(24); *p &= BIT3; p += dist0; FALLTHROUGH;
-        case 25: CHECK_FINISHED(25); *p &= BIT6; p += dist1; FALLTHROUGH;
-        case 26: CHECK_FINISHED(26); *p &= BIT0; p += dist2; FALLTHROUGH;
-        case 27: CHECK_FINISHED(27); *p &= BIT1; p += dist3; FALLTHROUGH;
-        case 28: CHECK_FINISHED(28); *p &= BIT4; p += dist2; FALLTHROUGH;
-        case 29: CHECK_FINISHED(29); *p &= BIT5; p += dist3; FALLTHROUGH;
-        case 30: CHECK_FINISHED(30); *p &= BIT7; p += dist6; FALLTHROUGH;
-        case 31: CHECK_FINISHED(31); *p &= BIT2; p += dist2;
+        case 24: CHECK_FINISHED(24); sieve[i] &= BIT3; i += dist0; FALLTHROUGH;
+        case 25: CHECK_FINISHED(25); sieve[i] &= BIT6; i += dist1; FALLTHROUGH;
+        case 26: CHECK_FINISHED(26); sieve[i] &= BIT0; i += dist2; FALLTHROUGH;
+        case 27: CHECK_FINISHED(27); sieve[i] &= BIT1; i += dist3; FALLTHROUGH;
+        case 28: CHECK_FINISHED(28); sieve[i] &= BIT4; i += dist2; FALLTHROUGH;
+        case 29: CHECK_FINISHED(29); sieve[i] &= BIT5; i += dist3; FALLTHROUGH;
+        case 30: CHECK_FINISHED(30); sieve[i] &= BIT7; i += dist6; FALLTHROUGH;
+        case 31: CHECK_FINISHED(31); sieve[i] &= BIT2; i += dist2;
       }
     }
   }
 }
 
 /// For sieving primes of type n % 30 == 19
-void EratMedium::crossOff_19(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
+void EratMedium::crossOff_19(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
@@ -287,8 +283,7 @@ void EratMedium::crossOff_19(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
   for (; prime != end; prime++)
   {
     uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t multipleIndex = prime->getMultipleIndex();
-    uint8_t* p = sieve + multipleIndex;
+    uint64_t i = prime->getMultipleIndex();
     uint64_t dist0 = sievingPrime * 6 + 4;
     uint64_t dist1 = sievingPrime * 4 + 2;
     uint64_t dist2 = sievingPrime * 2 + 2;
@@ -301,21 +296,21 @@ void EratMedium::crossOff_19(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
 
       for (;;)
       {
-        case 32: CHECK_FINISHED(32); *p &= BIT4; p += dist0; FALLTHROUGH;
-        case 33: CHECK_FINISHED(33); *p &= BIT2; p += dist1; FALLTHROUGH;
-        case 34: CHECK_FINISHED(34); *p &= BIT6; p += dist2; FALLTHROUGH;
-        case 35: CHECK_FINISHED(35); *p &= BIT0; p += dist1; FALLTHROUGH;
-        case 36: CHECK_FINISHED(36); *p &= BIT5; p += dist4; FALLTHROUGH;
-        case 37: CHECK_FINISHED(37); *p &= BIT7; p += dist5; FALLTHROUGH;
-        case 38: CHECK_FINISHED(38); *p &= BIT3; p += dist0; FALLTHROUGH;
-        case 39: CHECK_FINISHED(39); *p &= BIT1; p += dist4;
+        case 32: CHECK_FINISHED(32); sieve[i] &= BIT4; i += dist0; FALLTHROUGH;
+        case 33: CHECK_FINISHED(33); sieve[i] &= BIT2; i += dist1; FALLTHROUGH;
+        case 34: CHECK_FINISHED(34); sieve[i] &= BIT6; i += dist2; FALLTHROUGH;
+        case 35: CHECK_FINISHED(35); sieve[i] &= BIT0; i += dist1; FALLTHROUGH;
+        case 36: CHECK_FINISHED(36); sieve[i] &= BIT5; i += dist4; FALLTHROUGH;
+        case 37: CHECK_FINISHED(37); sieve[i] &= BIT7; i += dist5; FALLTHROUGH;
+        case 38: CHECK_FINISHED(38); sieve[i] &= BIT3; i += dist0; FALLTHROUGH;
+        case 39: CHECK_FINISHED(39); sieve[i] &= BIT1; i += dist4;
       }
     }
   }
 }
 
 /// For sieving primes of type n % 30 == 23
-void EratMedium::crossOff_23(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
+void EratMedium::crossOff_23(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
@@ -325,8 +320,7 @@ void EratMedium::crossOff_23(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
   for (; prime != end; prime++)
   {
     uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t multipleIndex = prime->getMultipleIndex();
-    uint8_t* p = sieve + multipleIndex;
+    uint64_t i = prime->getMultipleIndex();
     uint64_t dist0 = sievingPrime * 6 + 5;
     uint64_t dist1 = sievingPrime * 4 + 3;
     uint64_t dist2 = sievingPrime * 2 + 1;
@@ -338,21 +332,21 @@ void EratMedium::crossOff_23(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
 
       for (;;)
       {
-        case 40: CHECK_FINISHED(40); *p &= BIT5; p += dist0; FALLTHROUGH;
-        case 41: CHECK_FINISHED(41); *p &= BIT1; p += dist1; FALLTHROUGH;
-        case 42: CHECK_FINISHED(42); *p &= BIT2; p += dist2; FALLTHROUGH;
-        case 43: CHECK_FINISHED(43); *p &= BIT6; p += dist1; FALLTHROUGH;
-        case 44: CHECK_FINISHED(44); *p &= BIT7; p += dist4; FALLTHROUGH;
-        case 45: CHECK_FINISHED(45); *p &= BIT3; p += dist1; FALLTHROUGH;
-        case 46: CHECK_FINISHED(46); *p &= BIT4; p += dist0; FALLTHROUGH;
-        case 47: CHECK_FINISHED(47); *p &= BIT0; p += dist2;
+        case 40: CHECK_FINISHED(40); sieve[i] &= BIT5; i += dist0; FALLTHROUGH;
+        case 41: CHECK_FINISHED(41); sieve[i] &= BIT1; i += dist1; FALLTHROUGH;
+        case 42: CHECK_FINISHED(42); sieve[i] &= BIT2; i += dist2; FALLTHROUGH;
+        case 43: CHECK_FINISHED(43); sieve[i] &= BIT6; i += dist1; FALLTHROUGH;
+        case 44: CHECK_FINISHED(44); sieve[i] &= BIT7; i += dist4; FALLTHROUGH;
+        case 45: CHECK_FINISHED(45); sieve[i] &= BIT3; i += dist1; FALLTHROUGH;
+        case 46: CHECK_FINISHED(46); sieve[i] &= BIT4; i += dist0; FALLTHROUGH;
+        case 47: CHECK_FINISHED(47); sieve[i] &= BIT0; i += dist2;
       }
     }
   }
 }
 
 /// For sieving primes of type n % 30 == 29
-void EratMedium::crossOff_29(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
+void EratMedium::crossOff_29(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
@@ -362,8 +356,7 @@ void EratMedium::crossOff_29(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
   for (; prime != end; prime++)
   {
     uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t multipleIndex = prime->getMultipleIndex();
-    uint8_t* p = sieve + multipleIndex;
+    uint64_t i = prime->getMultipleIndex();
     uint64_t dist0 = sievingPrime * 6 + 6;
     uint64_t dist1 = sievingPrime * 4 + 4;
     uint64_t dist2 = sievingPrime * 2 + 2;
@@ -375,21 +368,21 @@ void EratMedium::crossOff_29(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
 
       for (;;)
       {
-        case 48: CHECK_FINISHED(48); *p &= BIT6; p += dist0; FALLTHROUGH;
-        case 49: CHECK_FINISHED(49); *p &= BIT5; p += dist1; FALLTHROUGH;
-        case 50: CHECK_FINISHED(50); *p &= BIT4; p += dist2; FALLTHROUGH;
-        case 51: CHECK_FINISHED(51); *p &= BIT3; p += dist1; FALLTHROUGH;
-        case 52: CHECK_FINISHED(52); *p &= BIT2; p += dist2; FALLTHROUGH;
-        case 53: CHECK_FINISHED(53); *p &= BIT1; p += dist1; FALLTHROUGH;
-        case 54: CHECK_FINISHED(54); *p &= BIT0; p += dist6; FALLTHROUGH;
-        case 55: CHECK_FINISHED(55); *p &= BIT7; p += dist2;
+        case 48: CHECK_FINISHED(48); sieve[i] &= BIT6; i += dist0; FALLTHROUGH;
+        case 49: CHECK_FINISHED(49); sieve[i] &= BIT5; i += dist1; FALLTHROUGH;
+        case 50: CHECK_FINISHED(50); sieve[i] &= BIT4; i += dist2; FALLTHROUGH;
+        case 51: CHECK_FINISHED(51); sieve[i] &= BIT3; i += dist1; FALLTHROUGH;
+        case 52: CHECK_FINISHED(52); sieve[i] &= BIT2; i += dist2; FALLTHROUGH;
+        case 53: CHECK_FINISHED(53); sieve[i] &= BIT1; i += dist1; FALLTHROUGH;
+        case 54: CHECK_FINISHED(54); sieve[i] &= BIT0; i += dist6; FALLTHROUGH;
+        case 55: CHECK_FINISHED(55); sieve[i] &= BIT7; i += dist2;
       }
     }
   }
 }
 
 /// For sieving primes of type n % 30 == 1
-void EratMedium::crossOff_31(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
+void EratMedium::crossOff_31(uint8_t* sieve, std::size_t sieveSize, Bucket* bucket)
 {
   SievingPrime* prime = bucket->begin();
   SievingPrime* end = bucket->end();
@@ -399,8 +392,7 @@ void EratMedium::crossOff_31(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
   for (; prime != end; prime++)
   {
     uint64_t sievingPrime = prime->getSievingPrime();
-    uint64_t multipleIndex = prime->getMultipleIndex();
-    uint8_t* p = sieve + multipleIndex;
+    uint64_t i = prime->getMultipleIndex();
     uint64_t dist0 = sievingPrime * 6 + 1;
     uint64_t dist1 = sievingPrime * 4 + 0;
     uint64_t dist2 = sievingPrime * 2 + 0;
@@ -412,14 +404,14 @@ void EratMedium::crossOff_31(uint8_t* sieve, uint8_t* sieveEnd, Bucket* bucket)
 
       for (;;)
       {
-        case 56: CHECK_FINISHED(56); *p &= BIT7; p += dist0; FALLTHROUGH;
-        case 57: CHECK_FINISHED(57); *p &= BIT0; p += dist1; FALLTHROUGH;
-        case 58: CHECK_FINISHED(58); *p &= BIT1; p += dist2; FALLTHROUGH;
-        case 59: CHECK_FINISHED(59); *p &= BIT2; p += dist1; FALLTHROUGH;
-        case 60: CHECK_FINISHED(60); *p &= BIT3; p += dist2; FALLTHROUGH;
-        case 61: CHECK_FINISHED(61); *p &= BIT4; p += dist1; FALLTHROUGH;
-        case 62: CHECK_FINISHED(62); *p &= BIT5; p += dist6; FALLTHROUGH;
-        case 63: CHECK_FINISHED(63); *p &= BIT6; p += dist2;
+        case 56: CHECK_FINISHED(56); sieve[i] &= BIT7; i += dist0; FALLTHROUGH;
+        case 57: CHECK_FINISHED(57); sieve[i] &= BIT0; i += dist1; FALLTHROUGH;
+        case 58: CHECK_FINISHED(58); sieve[i] &= BIT1; i += dist2; FALLTHROUGH;
+        case 59: CHECK_FINISHED(59); sieve[i] &= BIT2; i += dist1; FALLTHROUGH;
+        case 60: CHECK_FINISHED(60); sieve[i] &= BIT3; i += dist2; FALLTHROUGH;
+        case 61: CHECK_FINISHED(61); sieve[i] &= BIT4; i += dist1; FALLTHROUGH;
+        case 62: CHECK_FINISHED(62); sieve[i] &= BIT5; i += dist6; FALLTHROUGH;
+        case 63: CHECK_FINISHED(63); sieve[i] &= BIT6; i += dist2;
       }
     }
   }

--- a/src/EratSmall.cpp
+++ b/src/EratSmall.cpp
@@ -24,19 +24,6 @@
 #include <stdint.h>
 #include <algorithm>
 
-using std::size_t;
-
-/// Update the current sieving prime's multipleIndex
-/// and wheelIndex after sieving has finished.
-///
-#define CHECK_FINISHED(wheelIndex) \
-  if_unlikely(p >= sieveEnd) \
-  { \
-    multipleIndex = (uint64_t) (p - sieveEnd); \
-    prime.set(multipleIndex, wheelIndex); \
-    break; \
-  }
-
 namespace primesieve {
 
 /// @stop:        Upper bound for sieving
@@ -54,7 +41,7 @@ void EratSmall::init(uint64_t stop,
   stop_ = stop;
   maxPrime_ = maxPrime;
   l1CacheSize_ = (std::size_t) l1CacheSize;
-  size_t count = primeCountApprox(maxPrime);
+  std::size_t count = primeCountApprox(maxPrime);
   primes_.reserve(count);
 }
 
@@ -80,9 +67,8 @@ void EratSmall::crossOff(pod_vector<uint8_t>& sieve)
 {
   for (std::size_t i = 0; i < sieve.size(); i += l1CacheSize_)
   {
-    std::size_t end = i + l1CacheSize_;
-    end = std::min(end, sieve.size());
-    crossOff(sieve.data() + i, sieve.data() + end);
+    std::size_t sieveSize = std::min(l1CacheSize_, sieve.size() - i);
+    crossOff(&sieve[i], sieveSize);
   }
 }
 
@@ -91,19 +77,22 @@ void EratSmall::crossOff(pod_vector<uint8_t>& sieve)
 /// per segment. This algorithm uses a hardcoded modulo 30
 /// wheel that skips multiples of 2, 3 and 5.
 ///
-void EratSmall::crossOff(uint8_t* sieve, uint8_t* sieveEnd)
+void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
 {
   for (auto& prime : primes_)
   {
     uint64_t sievingPrime = prime.getSievingPrime();
-    uint64_t multipleIndex = prime.getMultipleIndex();
+    uint64_t i = prime.getMultipleIndex();
     uint64_t wheelIndex = prime.getWheelIndex();
     uint64_t maxLoopDist = sievingPrime * 28 + 27;
-    uint8_t* loopEnd = std::max(sieveEnd, sieve + maxLoopDist) - maxLoopDist;
+    uint64_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
 
-    // Pointer to the byte containing the first multiple of
-    // sievingPrime within the current segment.
-    uint8_t* p = &sieve[multipleIndex];
+    #define CHECK_FINISHED(wheelIndex) \
+      if_unlikely(i >= sieveSize) \
+      { \
+        prime.set(i - sieveSize, wheelIndex); \
+        break; \
+      }
 
     switch (wheelIndex)
     {
@@ -112,200 +101,200 @@ void EratSmall::crossOff(uint8_t* sieve, uint8_t* sieveEnd)
       {
         case 0: // Each iteration removes the next 8
                 // multiples of the sievingPrime.
-                for (; p < loopEnd; p += sievingPrime * 30 + 7)
+                for (; i < loopEnd; i += sievingPrime * 30 + 7)
                 {
-                  p[sievingPrime *  0 + 0] &= BIT0;
-                  p[sievingPrime *  6 + 1] &= BIT4;
-                  p[sievingPrime * 10 + 2] &= BIT3;
-                  p[sievingPrime * 12 + 2] &= BIT7;
-                  p[sievingPrime * 16 + 3] &= BIT6;
-                  p[sievingPrime * 18 + 4] &= BIT2;
-                  p[sievingPrime * 22 + 5] &= BIT1;
-                  p[sievingPrime * 28 + 6] &= BIT5;
+                  sieve[i + sievingPrime *  0 + 0] &= BIT0;
+                  sieve[i + sievingPrime *  6 + 1] &= BIT4;
+                  sieve[i + sievingPrime * 10 + 2] &= BIT3;
+                  sieve[i + sievingPrime * 12 + 2] &= BIT7;
+                  sieve[i + sievingPrime * 16 + 3] &= BIT6;
+                  sieve[i + sievingPrime * 18 + 4] &= BIT2;
+                  sieve[i + sievingPrime * 22 + 5] &= BIT1;
+                  sieve[i + sievingPrime * 28 + 6] &= BIT5;
                 }
-                CHECK_FINISHED(0); *p &= BIT0; p += sievingPrime * 6 + 1; FALLTHROUGH;
-        case 1: CHECK_FINISHED(1); *p &= BIT4; p += sievingPrime * 4 + 1; FALLTHROUGH;
-        case 2: CHECK_FINISHED(2); *p &= BIT3; p += sievingPrime * 2 + 0; FALLTHROUGH;
-        case 3: CHECK_FINISHED(3); *p &= BIT7; p += sievingPrime * 4 + 1; FALLTHROUGH;
-        case 4: CHECK_FINISHED(4); *p &= BIT6; p += sievingPrime * 2 + 1; FALLTHROUGH;
-        case 5: CHECK_FINISHED(5); *p &= BIT2; p += sievingPrime * 4 + 1; FALLTHROUGH;
-        case 6: CHECK_FINISHED(6); *p &= BIT1; p += sievingPrime * 6 + 1; FALLTHROUGH;
-        case 7: CHECK_FINISHED(7); *p &= BIT5; p += sievingPrime * 2 + 1;
+                CHECK_FINISHED(0); sieve[i] &= BIT0; i += sievingPrime * 6 + 1; FALLTHROUGH;
+        case 1: CHECK_FINISHED(1); sieve[i] &= BIT4; i += sievingPrime * 4 + 1; FALLTHROUGH;
+        case 2: CHECK_FINISHED(2); sieve[i] &= BIT3; i += sievingPrime * 2 + 0; FALLTHROUGH;
+        case 3: CHECK_FINISHED(3); sieve[i] &= BIT7; i += sievingPrime * 4 + 1; FALLTHROUGH;
+        case 4: CHECK_FINISHED(4); sieve[i] &= BIT6; i += sievingPrime * 2 + 1; FALLTHROUGH;
+        case 5: CHECK_FINISHED(5); sieve[i] &= BIT2; i += sievingPrime * 4 + 1; FALLTHROUGH;
+        case 6: CHECK_FINISHED(6); sieve[i] &= BIT1; i += sievingPrime * 6 + 1; FALLTHROUGH;
+        case 7: CHECK_FINISHED(7); sieve[i] &= BIT5; i += sievingPrime * 2 + 1;
       }
       break;
 
       // sievingPrime % 30 == 11
       for (;;)
       {
-        case  8: for (; p < loopEnd; p += sievingPrime * 30 + 11)
+        case  8: for (; i < loopEnd; i += sievingPrime * 30 + 11)
                  {
-                   p[sievingPrime *  0 +  0] &= BIT1;
-                   p[sievingPrime *  6 +  2] &= BIT3;
-                   p[sievingPrime * 10 +  3] &= BIT7;
-                   p[sievingPrime * 12 +  4] &= BIT5;
-                   p[sievingPrime * 16 +  6] &= BIT0;
-                   p[sievingPrime * 18 +  6] &= BIT6;
-                   p[sievingPrime * 22 +  8] &= BIT2;
-                   p[sievingPrime * 28 + 10] &= BIT4;
+                   sieve[i + sievingPrime *  0 +  0] &= BIT1;
+                   sieve[i + sievingPrime *  6 +  2] &= BIT3;
+                   sieve[i + sievingPrime * 10 +  3] &= BIT7;
+                   sieve[i + sievingPrime * 12 +  4] &= BIT5;
+                   sieve[i + sievingPrime * 16 +  6] &= BIT0;
+                   sieve[i + sievingPrime * 18 +  6] &= BIT6;
+                   sieve[i + sievingPrime * 22 +  8] &= BIT2;
+                   sieve[i + sievingPrime * 28 + 10] &= BIT4;
                  }
-                 CHECK_FINISHED( 8); *p &= BIT1; p += sievingPrime * 6 + 2; FALLTHROUGH;
-        case  9: CHECK_FINISHED( 9); *p &= BIT3; p += sievingPrime * 4 + 1; FALLTHROUGH;
-        case 10: CHECK_FINISHED(10); *p &= BIT7; p += sievingPrime * 2 + 1; FALLTHROUGH;
-        case 11: CHECK_FINISHED(11); *p &= BIT5; p += sievingPrime * 4 + 2; FALLTHROUGH;
-        case 12: CHECK_FINISHED(12); *p &= BIT0; p += sievingPrime * 2 + 0; FALLTHROUGH;
-        case 13: CHECK_FINISHED(13); *p &= BIT6; p += sievingPrime * 4 + 2; FALLTHROUGH;
-        case 14: CHECK_FINISHED(14); *p &= BIT2; p += sievingPrime * 6 + 2; FALLTHROUGH;
-        case 15: CHECK_FINISHED(15); *p &= BIT4; p += sievingPrime * 2 + 1;
+                 CHECK_FINISHED( 8); sieve[i] &= BIT1; i += sievingPrime * 6 + 2; FALLTHROUGH;
+        case  9: CHECK_FINISHED( 9); sieve[i] &= BIT3; i += sievingPrime * 4 + 1; FALLTHROUGH;
+        case 10: CHECK_FINISHED(10); sieve[i] &= BIT7; i += sievingPrime * 2 + 1; FALLTHROUGH;
+        case 11: CHECK_FINISHED(11); sieve[i] &= BIT5; i += sievingPrime * 4 + 2; FALLTHROUGH;
+        case 12: CHECK_FINISHED(12); sieve[i] &= BIT0; i += sievingPrime * 2 + 0; FALLTHROUGH;
+        case 13: CHECK_FINISHED(13); sieve[i] &= BIT6; i += sievingPrime * 4 + 2; FALLTHROUGH;
+        case 14: CHECK_FINISHED(14); sieve[i] &= BIT2; i += sievingPrime * 6 + 2; FALLTHROUGH;
+        case 15: CHECK_FINISHED(15); sieve[i] &= BIT4; i += sievingPrime * 2 + 1;
       }
       break;
 
       // sievingPrime % 30 == 13
       for (;;)
       {
-        case 16: for (; p < loopEnd; p += sievingPrime * 30 + 13)
+        case 16: for (; i < loopEnd; i += sievingPrime * 30 + 13)
                  {
-                   p[sievingPrime *  0 +  0] &= BIT2;
-                   p[sievingPrime *  6 +  2] &= BIT7;
-                   p[sievingPrime * 10 +  4] &= BIT5;
-                   p[sievingPrime * 12 +  5] &= BIT4;
-                   p[sievingPrime * 16 +  7] &= BIT1;
-                   p[sievingPrime * 18 +  8] &= BIT0;
-                   p[sievingPrime * 22 +  9] &= BIT6;
-                   p[sievingPrime * 28 + 12] &= BIT3;
+                   sieve[i + sievingPrime *  0 +  0] &= BIT2;
+                   sieve[i + sievingPrime *  6 +  2] &= BIT7;
+                   sieve[i + sievingPrime * 10 +  4] &= BIT5;
+                   sieve[i + sievingPrime * 12 +  5] &= BIT4;
+                   sieve[i + sievingPrime * 16 +  7] &= BIT1;
+                   sieve[i + sievingPrime * 18 +  8] &= BIT0;
+                   sieve[i + sievingPrime * 22 +  9] &= BIT6;
+                   sieve[i + sievingPrime * 28 + 12] &= BIT3;
                  }
-                 CHECK_FINISHED(16); *p &= BIT2; p += sievingPrime * 6 + 2; FALLTHROUGH;
-        case 17: CHECK_FINISHED(17); *p &= BIT7; p += sievingPrime * 4 + 2; FALLTHROUGH;
-        case 18: CHECK_FINISHED(18); *p &= BIT5; p += sievingPrime * 2 + 1; FALLTHROUGH;
-        case 19: CHECK_FINISHED(19); *p &= BIT4; p += sievingPrime * 4 + 2; FALLTHROUGH;
-        case 20: CHECK_FINISHED(20); *p &= BIT1; p += sievingPrime * 2 + 1; FALLTHROUGH;
-        case 21: CHECK_FINISHED(21); *p &= BIT0; p += sievingPrime * 4 + 1; FALLTHROUGH;
-        case 22: CHECK_FINISHED(22); *p &= BIT6; p += sievingPrime * 6 + 3; FALLTHROUGH;
-        case 23: CHECK_FINISHED(23); *p &= BIT3; p += sievingPrime * 2 + 1;
+                 CHECK_FINISHED(16); sieve[i] &= BIT2; i += sievingPrime * 6 + 2; FALLTHROUGH;
+        case 17: CHECK_FINISHED(17); sieve[i] &= BIT7; i += sievingPrime * 4 + 2; FALLTHROUGH;
+        case 18: CHECK_FINISHED(18); sieve[i] &= BIT5; i += sievingPrime * 2 + 1; FALLTHROUGH;
+        case 19: CHECK_FINISHED(19); sieve[i] &= BIT4; i += sievingPrime * 4 + 2; FALLTHROUGH;
+        case 20: CHECK_FINISHED(20); sieve[i] &= BIT1; i += sievingPrime * 2 + 1; FALLTHROUGH;
+        case 21: CHECK_FINISHED(21); sieve[i] &= BIT0; i += sievingPrime * 4 + 1; FALLTHROUGH;
+        case 22: CHECK_FINISHED(22); sieve[i] &= BIT6; i += sievingPrime * 6 + 3; FALLTHROUGH;
+        case 23: CHECK_FINISHED(23); sieve[i] &= BIT3; i += sievingPrime * 2 + 1;
       }
       break;
 
       // sievingPrime % 30 == 17
       for (;;)
       {
-        case 24: for (; p < loopEnd; p += sievingPrime * 30 + 17)
+        case 24: for (; i < loopEnd; i += sievingPrime * 30 + 17)
                  {
-                   p[sievingPrime *  0 +  0] &= BIT3;
-                   p[sievingPrime *  6 +  3] &= BIT6;
-                   p[sievingPrime * 10 +  6] &= BIT0;
-                   p[sievingPrime * 12 +  7] &= BIT1;
-                   p[sievingPrime * 16 +  9] &= BIT4;
-                   p[sievingPrime * 18 + 10] &= BIT5;
-                   p[sievingPrime * 22 + 12] &= BIT7;
-                   p[sievingPrime * 28 + 16] &= BIT2;
+                   sieve[i + sievingPrime *  0 +  0] &= BIT3;
+                   sieve[i + sievingPrime *  6 +  3] &= BIT6;
+                   sieve[i + sievingPrime * 10 +  6] &= BIT0;
+                   sieve[i + sievingPrime * 12 +  7] &= BIT1;
+                   sieve[i + sievingPrime * 16 +  9] &= BIT4;
+                   sieve[i + sievingPrime * 18 + 10] &= BIT5;
+                   sieve[i + sievingPrime * 22 + 12] &= BIT7;
+                   sieve[i + sievingPrime * 28 + 16] &= BIT2;
                  }
-                 CHECK_FINISHED(24); *p &= BIT3; p += sievingPrime * 6 + 3; FALLTHROUGH;
-        case 25: CHECK_FINISHED(25); *p &= BIT6; p += sievingPrime * 4 + 3; FALLTHROUGH;
-        case 26: CHECK_FINISHED(26); *p &= BIT0; p += sievingPrime * 2 + 1; FALLTHROUGH;
-        case 27: CHECK_FINISHED(27); *p &= BIT1; p += sievingPrime * 4 + 2; FALLTHROUGH;
-        case 28: CHECK_FINISHED(28); *p &= BIT4; p += sievingPrime * 2 + 1; FALLTHROUGH;
-        case 29: CHECK_FINISHED(29); *p &= BIT5; p += sievingPrime * 4 + 2; FALLTHROUGH;
-        case 30: CHECK_FINISHED(30); *p &= BIT7; p += sievingPrime * 6 + 4; FALLTHROUGH;
-        case 31: CHECK_FINISHED(31); *p &= BIT2; p += sievingPrime * 2 + 1;
+                 CHECK_FINISHED(24); sieve[i] &= BIT3; i += sievingPrime * 6 + 3; FALLTHROUGH;
+        case 25: CHECK_FINISHED(25); sieve[i] &= BIT6; i += sievingPrime * 4 + 3; FALLTHROUGH;
+        case 26: CHECK_FINISHED(26); sieve[i] &= BIT0; i += sievingPrime * 2 + 1; FALLTHROUGH;
+        case 27: CHECK_FINISHED(27); sieve[i] &= BIT1; i += sievingPrime * 4 + 2; FALLTHROUGH;
+        case 28: CHECK_FINISHED(28); sieve[i] &= BIT4; i += sievingPrime * 2 + 1; FALLTHROUGH;
+        case 29: CHECK_FINISHED(29); sieve[i] &= BIT5; i += sievingPrime * 4 + 2; FALLTHROUGH;
+        case 30: CHECK_FINISHED(30); sieve[i] &= BIT7; i += sievingPrime * 6 + 4; FALLTHROUGH;
+        case 31: CHECK_FINISHED(31); sieve[i] &= BIT2; i += sievingPrime * 2 + 1;
       }
       break;
 
       // sievingPrime % 30 == 19
       for (;;)
       {
-        case 32: for (; p < loopEnd; p += sievingPrime * 30 + 19)
+        case 32: for (; i < loopEnd; i += sievingPrime * 30 + 19)
                  {
-                   p[sievingPrime *  0 +  0] &= BIT4;
-                   p[sievingPrime *  6 +  4] &= BIT2;
-                   p[sievingPrime * 10 +  6] &= BIT6;
-                   p[sievingPrime * 12 +  8] &= BIT0;
-                   p[sievingPrime * 16 + 10] &= BIT5;
-                   p[sievingPrime * 18 + 11] &= BIT7;
-                   p[sievingPrime * 22 + 14] &= BIT3;
-                   p[sievingPrime * 28 + 18] &= BIT1;
+                   sieve[i + sievingPrime *  0 +  0] &= BIT4;
+                   sieve[i + sievingPrime *  6 +  4] &= BIT2;
+                   sieve[i + sievingPrime * 10 +  6] &= BIT6;
+                   sieve[i + sievingPrime * 12 +  8] &= BIT0;
+                   sieve[i + sievingPrime * 16 + 10] &= BIT5;
+                   sieve[i + sievingPrime * 18 + 11] &= BIT7;
+                   sieve[i + sievingPrime * 22 + 14] &= BIT3;
+                   sieve[i + sievingPrime * 28 + 18] &= BIT1;
                  }
-                 CHECK_FINISHED(32); *p &= BIT4; p += sievingPrime * 6 + 4; FALLTHROUGH;
-        case 33: CHECK_FINISHED(33); *p &= BIT2; p += sievingPrime * 4 + 2; FALLTHROUGH;
-        case 34: CHECK_FINISHED(34); *p &= BIT6; p += sievingPrime * 2 + 2; FALLTHROUGH;
-        case 35: CHECK_FINISHED(35); *p &= BIT0; p += sievingPrime * 4 + 2; FALLTHROUGH;
-        case 36: CHECK_FINISHED(36); *p &= BIT5; p += sievingPrime * 2 + 1; FALLTHROUGH;
-        case 37: CHECK_FINISHED(37); *p &= BIT7; p += sievingPrime * 4 + 3; FALLTHROUGH;
-        case 38: CHECK_FINISHED(38); *p &= BIT3; p += sievingPrime * 6 + 4; FALLTHROUGH;
-        case 39: CHECK_FINISHED(39); *p &= BIT1; p += sievingPrime * 2 + 1;
+                 CHECK_FINISHED(32); sieve[i] &= BIT4; i += sievingPrime * 6 + 4; FALLTHROUGH;
+        case 33: CHECK_FINISHED(33); sieve[i] &= BIT2; i += sievingPrime * 4 + 2; FALLTHROUGH;
+        case 34: CHECK_FINISHED(34); sieve[i] &= BIT6; i += sievingPrime * 2 + 2; FALLTHROUGH;
+        case 35: CHECK_FINISHED(35); sieve[i] &= BIT0; i += sievingPrime * 4 + 2; FALLTHROUGH;
+        case 36: CHECK_FINISHED(36); sieve[i] &= BIT5; i += sievingPrime * 2 + 1; FALLTHROUGH;
+        case 37: CHECK_FINISHED(37); sieve[i] &= BIT7; i += sievingPrime * 4 + 3; FALLTHROUGH;
+        case 38: CHECK_FINISHED(38); sieve[i] &= BIT3; i += sievingPrime * 6 + 4; FALLTHROUGH;
+        case 39: CHECK_FINISHED(39); sieve[i] &= BIT1; i += sievingPrime * 2 + 1;
       }
       break;
 
       // sievingPrime % 30 == 23
       for (;;)
       {
-        case 40: for (; p < loopEnd; p += sievingPrime * 30 + 23)
+        case 40: for (; i < loopEnd; i += sievingPrime * 30 + 23)
                  {
-                   p[sievingPrime *  0 +  0] &= BIT5;
-                   p[sievingPrime *  6 +  5] &= BIT1;
-                   p[sievingPrime * 10 +  8] &= BIT2;
-                   p[sievingPrime * 12 +  9] &= BIT6;
-                   p[sievingPrime * 16 + 12] &= BIT7;
-                   p[sievingPrime * 18 + 14] &= BIT3;
-                   p[sievingPrime * 22 + 17] &= BIT4;
-                   p[sievingPrime * 28 + 22] &= BIT0;
+                   sieve[i + sievingPrime *  0 +  0] &= BIT5;
+                   sieve[i + sievingPrime *  6 +  5] &= BIT1;
+                   sieve[i + sievingPrime * 10 +  8] &= BIT2;
+                   sieve[i + sievingPrime * 12 +  9] &= BIT6;
+                   sieve[i + sievingPrime * 16 + 12] &= BIT7;
+                   sieve[i + sievingPrime * 18 + 14] &= BIT3;
+                   sieve[i + sievingPrime * 22 + 17] &= BIT4;
+                   sieve[i + sievingPrime * 28 + 22] &= BIT0;
                  }
-                 CHECK_FINISHED(40); *p &= BIT5; p += sievingPrime * 6 + 5; FALLTHROUGH;
-        case 41: CHECK_FINISHED(41); *p &= BIT1; p += sievingPrime * 4 + 3; FALLTHROUGH;
-        case 42: CHECK_FINISHED(42); *p &= BIT2; p += sievingPrime * 2 + 1; FALLTHROUGH;
-        case 43: CHECK_FINISHED(43); *p &= BIT6; p += sievingPrime * 4 + 3; FALLTHROUGH;
-        case 44: CHECK_FINISHED(44); *p &= BIT7; p += sievingPrime * 2 + 2; FALLTHROUGH;
-        case 45: CHECK_FINISHED(45); *p &= BIT3; p += sievingPrime * 4 + 3; FALLTHROUGH;
-        case 46: CHECK_FINISHED(46); *p &= BIT4; p += sievingPrime * 6 + 5; FALLTHROUGH;
-        case 47: CHECK_FINISHED(47); *p &= BIT0; p += sievingPrime * 2 + 1;
+                 CHECK_FINISHED(40); sieve[i] &= BIT5; i += sievingPrime * 6 + 5; FALLTHROUGH;
+        case 41: CHECK_FINISHED(41); sieve[i] &= BIT1; i += sievingPrime * 4 + 3; FALLTHROUGH;
+        case 42: CHECK_FINISHED(42); sieve[i] &= BIT2; i += sievingPrime * 2 + 1; FALLTHROUGH;
+        case 43: CHECK_FINISHED(43); sieve[i] &= BIT6; i += sievingPrime * 4 + 3; FALLTHROUGH;
+        case 44: CHECK_FINISHED(44); sieve[i] &= BIT7; i += sievingPrime * 2 + 2; FALLTHROUGH;
+        case 45: CHECK_FINISHED(45); sieve[i] &= BIT3; i += sievingPrime * 4 + 3; FALLTHROUGH;
+        case 46: CHECK_FINISHED(46); sieve[i] &= BIT4; i += sievingPrime * 6 + 5; FALLTHROUGH;
+        case 47: CHECK_FINISHED(47); sieve[i] &= BIT0; i += sievingPrime * 2 + 1;
       }
       break;
 
       // sievingPrime % 30 == 29
       for (;;)
       {
-        case 48: for (; p < loopEnd; p += sievingPrime * 30 + 29)
+        case 48: for (; i < loopEnd; i += sievingPrime * 30 + 29)
                  {
-                   p[sievingPrime *  0 +  0] &= BIT6;
-                   p[sievingPrime *  6 +  6] &= BIT5;
-                   p[sievingPrime * 10 + 10] &= BIT4;
-                   p[sievingPrime * 12 + 12] &= BIT3;
-                   p[sievingPrime * 16 + 16] &= BIT2;
-                   p[sievingPrime * 18 + 18] &= BIT1;
-                   p[sievingPrime * 22 + 22] &= BIT0;
-                   p[sievingPrime * 28 + 27] &= BIT7;
+                   sieve[i + sievingPrime *  0 +  0] &= BIT6;
+                   sieve[i + sievingPrime *  6 +  6] &= BIT5;
+                   sieve[i + sievingPrime * 10 + 10] &= BIT4;
+                   sieve[i + sievingPrime * 12 + 12] &= BIT3;
+                   sieve[i + sievingPrime * 16 + 16] &= BIT2;
+                   sieve[i + sievingPrime * 18 + 18] &= BIT1;
+                   sieve[i + sievingPrime * 22 + 22] &= BIT0;
+                   sieve[i + sievingPrime * 28 + 27] &= BIT7;
                  }
-                 CHECK_FINISHED(48); *p &= BIT6; p += sievingPrime * 6 + 6; FALLTHROUGH;
-        case 49: CHECK_FINISHED(49); *p &= BIT5; p += sievingPrime * 4 + 4; FALLTHROUGH;
-        case 50: CHECK_FINISHED(50); *p &= BIT4; p += sievingPrime * 2 + 2; FALLTHROUGH;
-        case 51: CHECK_FINISHED(51); *p &= BIT3; p += sievingPrime * 4 + 4; FALLTHROUGH;
-        case 52: CHECK_FINISHED(52); *p &= BIT2; p += sievingPrime * 2 + 2; FALLTHROUGH;
-        case 53: CHECK_FINISHED(53); *p &= BIT1; p += sievingPrime * 4 + 4; FALLTHROUGH;
-        case 54: CHECK_FINISHED(54); *p &= BIT0; p += sievingPrime * 6 + 5; FALLTHROUGH;
-        case 55: CHECK_FINISHED(55); *p &= BIT7; p += sievingPrime * 2 + 2;
+                 CHECK_FINISHED(48); sieve[i] &= BIT6; i += sievingPrime * 6 + 6; FALLTHROUGH;
+        case 49: CHECK_FINISHED(49); sieve[i] &= BIT5; i += sievingPrime * 4 + 4; FALLTHROUGH;
+        case 50: CHECK_FINISHED(50); sieve[i] &= BIT4; i += sievingPrime * 2 + 2; FALLTHROUGH;
+        case 51: CHECK_FINISHED(51); sieve[i] &= BIT3; i += sievingPrime * 4 + 4; FALLTHROUGH;
+        case 52: CHECK_FINISHED(52); sieve[i] &= BIT2; i += sievingPrime * 2 + 2; FALLTHROUGH;
+        case 53: CHECK_FINISHED(53); sieve[i] &= BIT1; i += sievingPrime * 4 + 4; FALLTHROUGH;
+        case 54: CHECK_FINISHED(54); sieve[i] &= BIT0; i += sievingPrime * 6 + 5; FALLTHROUGH;
+        case 55: CHECK_FINISHED(55); sieve[i] &= BIT7; i += sievingPrime * 2 + 2;
       }
       break;
 
       // sievingPrime % 30 == 1
       for (;;)
       {
-        case 56: for (; p < loopEnd; p += sievingPrime * 30 + 1)
+        case 56: for (; i < loopEnd; i += sievingPrime * 30 + 1)
                  {
-                   p[sievingPrime *  0 + 0] &= BIT7;
-                   p[sievingPrime *  6 + 1] &= BIT0;
-                   p[sievingPrime * 10 + 1] &= BIT1;
-                   p[sievingPrime * 12 + 1] &= BIT2;
-                   p[sievingPrime * 16 + 1] &= BIT3;
-                   p[sievingPrime * 18 + 1] &= BIT4;
-                   p[sievingPrime * 22 + 1] &= BIT5;
-                   p[sievingPrime * 28 + 1] &= BIT6;
+                   sieve[i + sievingPrime *  0 + 0] &= BIT7;
+                   sieve[i + sievingPrime *  6 + 1] &= BIT0;
+                   sieve[i + sievingPrime * 10 + 1] &= BIT1;
+                   sieve[i + sievingPrime * 12 + 1] &= BIT2;
+                   sieve[i + sievingPrime * 16 + 1] &= BIT3;
+                   sieve[i + sievingPrime * 18 + 1] &= BIT4;
+                   sieve[i + sievingPrime * 22 + 1] &= BIT5;
+                   sieve[i + sievingPrime * 28 + 1] &= BIT6;
                  }
-                 CHECK_FINISHED(56); *p &= BIT7; p += sievingPrime * 6 + 1; FALLTHROUGH;
-        case 57: CHECK_FINISHED(57); *p &= BIT0; p += sievingPrime * 4 + 0; FALLTHROUGH;
-        case 58: CHECK_FINISHED(58); *p &= BIT1; p += sievingPrime * 2 + 0; FALLTHROUGH;
-        case 59: CHECK_FINISHED(59); *p &= BIT2; p += sievingPrime * 4 + 0; FALLTHROUGH;
-        case 60: CHECK_FINISHED(60); *p &= BIT3; p += sievingPrime * 2 + 0; FALLTHROUGH;
-        case 61: CHECK_FINISHED(61); *p &= BIT4; p += sievingPrime * 4 + 0; FALLTHROUGH;
-        case 62: CHECK_FINISHED(62); *p &= BIT5; p += sievingPrime * 6 + 0; FALLTHROUGH;
-        case 63: CHECK_FINISHED(63); *p &= BIT6; p += sievingPrime * 2 + 0;
+                 CHECK_FINISHED(56); sieve[i] &= BIT7; i += sievingPrime * 6 + 1; FALLTHROUGH;
+        case 57: CHECK_FINISHED(57); sieve[i] &= BIT0; i += sievingPrime * 4 + 0; FALLTHROUGH;
+        case 58: CHECK_FINISHED(58); sieve[i] &= BIT1; i += sievingPrime * 2 + 0; FALLTHROUGH;
+        case 59: CHECK_FINISHED(59); sieve[i] &= BIT2; i += sievingPrime * 4 + 0; FALLTHROUGH;
+        case 60: CHECK_FINISHED(60); sieve[i] &= BIT3; i += sievingPrime * 2 + 0; FALLTHROUGH;
+        case 61: CHECK_FINISHED(61); sieve[i] &= BIT4; i += sievingPrime * 4 + 0; FALLTHROUGH;
+        case 62: CHECK_FINISHED(62); sieve[i] &= BIT5; i += sievingPrime * 6 + 0; FALLTHROUGH;
+        case 63: CHECK_FINISHED(63); sieve[i] &= BIT6; i += sievingPrime * 2 + 0;
       }
       break;
 

--- a/src/EratSmall.cpp
+++ b/src/EratSmall.cpp
@@ -90,7 +90,8 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
     #define CHECK_FINISHED(wheelIndex) \
       if_unlikely(i >= sieveSize) \
       { \
-        prime.set(i - sieveSize, wheelIndex); \
+        uint64_t multipleIndex = i - sieveSize; \
+        prime.set(multipleIndex, wheelIndex); \
         break; \
       }
 

--- a/src/EratSmall.cpp
+++ b/src/EratSmall.cpp
@@ -79,39 +79,42 @@ void EratSmall::crossOff(pod_vector<uint8_t>& sieve)
 ///
 void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
 {
+  #define CHECK_FINISHED(wheelIndex) \
+    if (i >= sieveSize) \
+    { \
+      std::size_t multipleIndex = i - sieveSize; \
+      prime.set(multipleIndex, wheelIndex); \
+      goto next_iteration; \
+    }
+
   for (auto& prime : primes_)
   {
     std::size_t sievingPrime = prime.getSievingPrime();
     std::size_t i = prime.getMultipleIndex();
     std::size_t wheelIndex = prime.getWheelIndex();
-    std::size_t maxLoopDist = sievingPrime * 28 + 27;
-    std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
-
-    #define CHECK_FINISHED(wheelIndex) \
-      if_unlikely(i >= sieveSize) \
-      { \
-        std::size_t multipleIndex = i - sieveSize; \
-        prime.set(multipleIndex, wheelIndex); \
-        break; \
-      }
 
     switch (wheelIndex)
     {
       // sievingPrime % 30 == 7
       for (;;)
       {
-        case 0: // Each iteration removes the next 8
-                // multiples of the sievingPrime.
-                for (; i < loopEnd; i += sievingPrime * 30 + 7)
-                {
-                  sieve[i + sievingPrime *  0 + 0] &= BIT0;
-                  sieve[i + sievingPrime *  6 + 1] &= BIT4;
-                  sieve[i + sievingPrime * 10 + 2] &= BIT3;
-                  sieve[i + sievingPrime * 12 + 2] &= BIT7;
-                  sieve[i + sievingPrime * 16 + 3] &= BIT6;
-                  sieve[i + sievingPrime * 18 + 4] &= BIT2;
-                  sieve[i + sievingPrime * 22 + 5] &= BIT1;
-                  sieve[i + sievingPrime * 28 + 6] &= BIT5;
+        case 0: {
+                  std::size_t maxLoopDist = sievingPrime * 28 + 6;
+                  std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+
+                  // Each iteration removes the next 8
+                  // multiples of the sievingPrime.
+                  for (; i < loopEnd; i += sievingPrime * 30 + 7)
+                  {
+                    sieve[i + sievingPrime *  0 + 0] &= BIT0;
+                    sieve[i + sievingPrime *  6 + 1] &= BIT4;
+                    sieve[i + sievingPrime * 10 + 2] &= BIT3;
+                    sieve[i + sievingPrime * 12 + 2] &= BIT7;
+                    sieve[i + sievingPrime * 16 + 3] &= BIT6;
+                    sieve[i + sievingPrime * 18 + 4] &= BIT2;
+                    sieve[i + sievingPrime * 22 + 5] &= BIT1;
+                    sieve[i + sievingPrime * 28 + 6] &= BIT5;
+                  }
                 }
                 CHECK_FINISHED(0); sieve[i] &= BIT0; i += sievingPrime * 6 + 1; FALLTHROUGH;
         case 1: CHECK_FINISHED(1); sieve[i] &= BIT4; i += sievingPrime * 4 + 1; FALLTHROUGH;
@@ -122,21 +125,25 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
         case 6: CHECK_FINISHED(6); sieve[i] &= BIT1; i += sievingPrime * 6 + 1; FALLTHROUGH;
         case 7: CHECK_FINISHED(7); sieve[i] &= BIT5; i += sievingPrime * 2 + 1;
       }
-      break;
 
       // sievingPrime % 30 == 11
       for (;;)
       {
-        case  8: for (; i < loopEnd; i += sievingPrime * 30 + 11)
-                 {
-                   sieve[i + sievingPrime *  0 +  0] &= BIT1;
-                   sieve[i + sievingPrime *  6 +  2] &= BIT3;
-                   sieve[i + sievingPrime * 10 +  3] &= BIT7;
-                   sieve[i + sievingPrime * 12 +  4] &= BIT5;
-                   sieve[i + sievingPrime * 16 +  6] &= BIT0;
-                   sieve[i + sievingPrime * 18 +  6] &= BIT6;
-                   sieve[i + sievingPrime * 22 +  8] &= BIT2;
-                   sieve[i + sievingPrime * 28 + 10] &= BIT4;
+        case  8: {
+                   std::size_t maxLoopDist = sievingPrime * 28 + 10;
+                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+
+                   for (; i < loopEnd; i += sievingPrime * 30 + 11)
+                   {
+                     sieve[i + sievingPrime *  0 +  0] &= BIT1;
+                     sieve[i + sievingPrime *  6 +  2] &= BIT3;
+                     sieve[i + sievingPrime * 10 +  3] &= BIT7;
+                     sieve[i + sievingPrime * 12 +  4] &= BIT5;
+                     sieve[i + sievingPrime * 16 +  6] &= BIT0;
+                     sieve[i + sievingPrime * 18 +  6] &= BIT6;
+                     sieve[i + sievingPrime * 22 +  8] &= BIT2;
+                     sieve[i + sievingPrime * 28 + 10] &= BIT4;
+                   }
                  }
                  CHECK_FINISHED( 8); sieve[i] &= BIT1; i += sievingPrime * 6 + 2; FALLTHROUGH;
         case  9: CHECK_FINISHED( 9); sieve[i] &= BIT3; i += sievingPrime * 4 + 1; FALLTHROUGH;
@@ -147,21 +154,25 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
         case 14: CHECK_FINISHED(14); sieve[i] &= BIT2; i += sievingPrime * 6 + 2; FALLTHROUGH;
         case 15: CHECK_FINISHED(15); sieve[i] &= BIT4; i += sievingPrime * 2 + 1;
       }
-      break;
 
       // sievingPrime % 30 == 13
       for (;;)
       {
-        case 16: for (; i < loopEnd; i += sievingPrime * 30 + 13)
-                 {
-                   sieve[i + sievingPrime *  0 +  0] &= BIT2;
-                   sieve[i + sievingPrime *  6 +  2] &= BIT7;
-                   sieve[i + sievingPrime * 10 +  4] &= BIT5;
-                   sieve[i + sievingPrime * 12 +  5] &= BIT4;
-                   sieve[i + sievingPrime * 16 +  7] &= BIT1;
-                   sieve[i + sievingPrime * 18 +  8] &= BIT0;
-                   sieve[i + sievingPrime * 22 +  9] &= BIT6;
-                   sieve[i + sievingPrime * 28 + 12] &= BIT3;
+        case 16: {
+                   std::size_t maxLoopDist = sievingPrime * 28 + 12;
+                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+
+                   for (; i < loopEnd; i += sievingPrime * 30 + 13)
+                   {
+                     sieve[i + sievingPrime *  0 +  0] &= BIT2;
+                     sieve[i + sievingPrime *  6 +  2] &= BIT7;
+                     sieve[i + sievingPrime * 10 +  4] &= BIT5;
+                     sieve[i + sievingPrime * 12 +  5] &= BIT4;
+                     sieve[i + sievingPrime * 16 +  7] &= BIT1;
+                     sieve[i + sievingPrime * 18 +  8] &= BIT0;
+                     sieve[i + sievingPrime * 22 +  9] &= BIT6;
+                     sieve[i + sievingPrime * 28 + 12] &= BIT3;
+                   }
                  }
                  CHECK_FINISHED(16); sieve[i] &= BIT2; i += sievingPrime * 6 + 2; FALLTHROUGH;
         case 17: CHECK_FINISHED(17); sieve[i] &= BIT7; i += sievingPrime * 4 + 2; FALLTHROUGH;
@@ -172,21 +183,25 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
         case 22: CHECK_FINISHED(22); sieve[i] &= BIT6; i += sievingPrime * 6 + 3; FALLTHROUGH;
         case 23: CHECK_FINISHED(23); sieve[i] &= BIT3; i += sievingPrime * 2 + 1;
       }
-      break;
 
       // sievingPrime % 30 == 17
       for (;;)
       {
-        case 24: for (; i < loopEnd; i += sievingPrime * 30 + 17)
-                 {
-                   sieve[i + sievingPrime *  0 +  0] &= BIT3;
-                   sieve[i + sievingPrime *  6 +  3] &= BIT6;
-                   sieve[i + sievingPrime * 10 +  6] &= BIT0;
-                   sieve[i + sievingPrime * 12 +  7] &= BIT1;
-                   sieve[i + sievingPrime * 16 +  9] &= BIT4;
-                   sieve[i + sievingPrime * 18 + 10] &= BIT5;
-                   sieve[i + sievingPrime * 22 + 12] &= BIT7;
-                   sieve[i + sievingPrime * 28 + 16] &= BIT2;
+        case 24: {
+                   std::size_t maxLoopDist = sievingPrime * 28 + 16;
+                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+
+                   for (; i < loopEnd; i += sievingPrime * 30 + 17)
+                   {
+                     sieve[i + sievingPrime *  0 +  0] &= BIT3;
+                     sieve[i + sievingPrime *  6 +  3] &= BIT6;
+                     sieve[i + sievingPrime * 10 +  6] &= BIT0;
+                     sieve[i + sievingPrime * 12 +  7] &= BIT1;
+                     sieve[i + sievingPrime * 16 +  9] &= BIT4;
+                     sieve[i + sievingPrime * 18 + 10] &= BIT5;
+                     sieve[i + sievingPrime * 22 + 12] &= BIT7;
+                     sieve[i + sievingPrime * 28 + 16] &= BIT2;
+                   }
                  }
                  CHECK_FINISHED(24); sieve[i] &= BIT3; i += sievingPrime * 6 + 3; FALLTHROUGH;
         case 25: CHECK_FINISHED(25); sieve[i] &= BIT6; i += sievingPrime * 4 + 3; FALLTHROUGH;
@@ -197,21 +212,25 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
         case 30: CHECK_FINISHED(30); sieve[i] &= BIT7; i += sievingPrime * 6 + 4; FALLTHROUGH;
         case 31: CHECK_FINISHED(31); sieve[i] &= BIT2; i += sievingPrime * 2 + 1;
       }
-      break;
 
       // sievingPrime % 30 == 19
       for (;;)
       {
-        case 32: for (; i < loopEnd; i += sievingPrime * 30 + 19)
-                 {
-                   sieve[i + sievingPrime *  0 +  0] &= BIT4;
-                   sieve[i + sievingPrime *  6 +  4] &= BIT2;
-                   sieve[i + sievingPrime * 10 +  6] &= BIT6;
-                   sieve[i + sievingPrime * 12 +  8] &= BIT0;
-                   sieve[i + sievingPrime * 16 + 10] &= BIT5;
-                   sieve[i + sievingPrime * 18 + 11] &= BIT7;
-                   sieve[i + sievingPrime * 22 + 14] &= BIT3;
-                   sieve[i + sievingPrime * 28 + 18] &= BIT1;
+        case 32: {
+                   std::size_t maxLoopDist = sievingPrime * 28 + 18;
+                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+
+                   for (; i < loopEnd; i += sievingPrime * 30 + 19)
+                   {
+                     sieve[i + sievingPrime *  0 +  0] &= BIT4;
+                     sieve[i + sievingPrime *  6 +  4] &= BIT2;
+                     sieve[i + sievingPrime * 10 +  6] &= BIT6;
+                     sieve[i + sievingPrime * 12 +  8] &= BIT0;
+                     sieve[i + sievingPrime * 16 + 10] &= BIT5;
+                     sieve[i + sievingPrime * 18 + 11] &= BIT7;
+                     sieve[i + sievingPrime * 22 + 14] &= BIT3;
+                     sieve[i + sievingPrime * 28 + 18] &= BIT1;
+                   }
                  }
                  CHECK_FINISHED(32); sieve[i] &= BIT4; i += sievingPrime * 6 + 4; FALLTHROUGH;
         case 33: CHECK_FINISHED(33); sieve[i] &= BIT2; i += sievingPrime * 4 + 2; FALLTHROUGH;
@@ -222,21 +241,25 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
         case 38: CHECK_FINISHED(38); sieve[i] &= BIT3; i += sievingPrime * 6 + 4; FALLTHROUGH;
         case 39: CHECK_FINISHED(39); sieve[i] &= BIT1; i += sievingPrime * 2 + 1;
       }
-      break;
 
       // sievingPrime % 30 == 23
       for (;;)
       {
-        case 40: for (; i < loopEnd; i += sievingPrime * 30 + 23)
-                 {
-                   sieve[i + sievingPrime *  0 +  0] &= BIT5;
-                   sieve[i + sievingPrime *  6 +  5] &= BIT1;
-                   sieve[i + sievingPrime * 10 +  8] &= BIT2;
-                   sieve[i + sievingPrime * 12 +  9] &= BIT6;
-                   sieve[i + sievingPrime * 16 + 12] &= BIT7;
-                   sieve[i + sievingPrime * 18 + 14] &= BIT3;
-                   sieve[i + sievingPrime * 22 + 17] &= BIT4;
-                   sieve[i + sievingPrime * 28 + 22] &= BIT0;
+        case 40: {
+                   std::size_t maxLoopDist = sievingPrime * 28 + 22;
+                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+
+                   for (; i < loopEnd; i += sievingPrime * 30 + 23)
+                   {
+                     sieve[i + sievingPrime *  0 +  0] &= BIT5;
+                     sieve[i + sievingPrime *  6 +  5] &= BIT1;
+                     sieve[i + sievingPrime * 10 +  8] &= BIT2;
+                     sieve[i + sievingPrime * 12 +  9] &= BIT6;
+                     sieve[i + sievingPrime * 16 + 12] &= BIT7;
+                     sieve[i + sievingPrime * 18 + 14] &= BIT3;
+                     sieve[i + sievingPrime * 22 + 17] &= BIT4;
+                     sieve[i + sievingPrime * 28 + 22] &= BIT0;
+                   }
                  }
                  CHECK_FINISHED(40); sieve[i] &= BIT5; i += sievingPrime * 6 + 5; FALLTHROUGH;
         case 41: CHECK_FINISHED(41); sieve[i] &= BIT1; i += sievingPrime * 4 + 3; FALLTHROUGH;
@@ -247,21 +270,25 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
         case 46: CHECK_FINISHED(46); sieve[i] &= BIT4; i += sievingPrime * 6 + 5; FALLTHROUGH;
         case 47: CHECK_FINISHED(47); sieve[i] &= BIT0; i += sievingPrime * 2 + 1;
       }
-      break;
 
       // sievingPrime % 30 == 29
       for (;;)
       {
-        case 48: for (; i < loopEnd; i += sievingPrime * 30 + 29)
-                 {
-                   sieve[i + sievingPrime *  0 +  0] &= BIT6;
-                   sieve[i + sievingPrime *  6 +  6] &= BIT5;
-                   sieve[i + sievingPrime * 10 + 10] &= BIT4;
-                   sieve[i + sievingPrime * 12 + 12] &= BIT3;
-                   sieve[i + sievingPrime * 16 + 16] &= BIT2;
-                   sieve[i + sievingPrime * 18 + 18] &= BIT1;
-                   sieve[i + sievingPrime * 22 + 22] &= BIT0;
-                   sieve[i + sievingPrime * 28 + 27] &= BIT7;
+        case 48: {
+                   std::size_t maxLoopDist = sievingPrime * 28 + 27;
+                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+
+                   for (; i < loopEnd; i += sievingPrime * 30 + 29)
+                   {
+                     sieve[i + sievingPrime *  0 +  0] &= BIT6;
+                     sieve[i + sievingPrime *  6 +  6] &= BIT5;
+                     sieve[i + sievingPrime * 10 + 10] &= BIT4;
+                     sieve[i + sievingPrime * 12 + 12] &= BIT3;
+                     sieve[i + sievingPrime * 16 + 16] &= BIT2;
+                     sieve[i + sievingPrime * 18 + 18] &= BIT1;
+                     sieve[i + sievingPrime * 22 + 22] &= BIT0;
+                     sieve[i + sievingPrime * 28 + 27] &= BIT7;
+                   }
                  }
                  CHECK_FINISHED(48); sieve[i] &= BIT6; i += sievingPrime * 6 + 6; FALLTHROUGH;
         case 49: CHECK_FINISHED(49); sieve[i] &= BIT5; i += sievingPrime * 4 + 4; FALLTHROUGH;
@@ -272,21 +299,25 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
         case 54: CHECK_FINISHED(54); sieve[i] &= BIT0; i += sievingPrime * 6 + 5; FALLTHROUGH;
         case 55: CHECK_FINISHED(55); sieve[i] &= BIT7; i += sievingPrime * 2 + 2;
       }
-      break;
 
       // sievingPrime % 30 == 1
       for (;;)
       {
-        case 56: for (; i < loopEnd; i += sievingPrime * 30 + 1)
-                 {
-                   sieve[i + sievingPrime *  0 + 0] &= BIT7;
-                   sieve[i + sievingPrime *  6 + 1] &= BIT0;
-                   sieve[i + sievingPrime * 10 + 1] &= BIT1;
-                   sieve[i + sievingPrime * 12 + 1] &= BIT2;
-                   sieve[i + sievingPrime * 16 + 1] &= BIT3;
-                   sieve[i + sievingPrime * 18 + 1] &= BIT4;
-                   sieve[i + sievingPrime * 22 + 1] &= BIT5;
-                   sieve[i + sievingPrime * 28 + 1] &= BIT6;
+        case 56: {
+                   std::size_t maxLoopDist = sievingPrime * 28 + 1;
+                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+
+                   for (; i < loopEnd; i += sievingPrime * 30 + 1)
+                   {
+                     sieve[i + sievingPrime *  0 + 0] &= BIT7;
+                     sieve[i + sievingPrime *  6 + 1] &= BIT0;
+                     sieve[i + sievingPrime * 10 + 1] &= BIT1;
+                     sieve[i + sievingPrime * 12 + 1] &= BIT2;
+                     sieve[i + sievingPrime * 16 + 1] &= BIT3;
+                     sieve[i + sievingPrime * 18 + 1] &= BIT4;
+                     sieve[i + sievingPrime * 22 + 1] &= BIT5;
+                     sieve[i + sievingPrime * 28 + 1] &= BIT6;
+                   }
                  }
                  CHECK_FINISHED(56); sieve[i] &= BIT7; i += sievingPrime * 6 + 1; FALLTHROUGH;
         case 57: CHECK_FINISHED(57); sieve[i] &= BIT0; i += sievingPrime * 4 + 0; FALLTHROUGH;
@@ -297,10 +328,11 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
         case 62: CHECK_FINISHED(62); sieve[i] &= BIT5; i += sievingPrime * 6 + 0; FALLTHROUGH;
         case 63: CHECK_FINISHED(63); sieve[i] &= BIT6; i += sievingPrime * 2 + 0;
       }
-      break;
 
       default: UNREACHABLE;
     }
+
+    next_iteration:;
   }
 }
 

--- a/src/EratSmall.cpp
+++ b/src/EratSmall.cpp
@@ -100,11 +100,11 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       {
         case 0: {
                   std::size_t maxLoopDist = sievingPrime * 28 + 6;
-                  std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                  std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
 
                   // Each iteration removes the next 8
                   // multiples of the sievingPrime.
-                  for (; i < loopEnd; i += sievingPrime * 30 + 7)
+                  for (; i < limit; i += sievingPrime * 30 + 7)
                   {
                     sieve[i + sievingPrime *  0 + 0] &= BIT0;
                     sieve[i + sievingPrime *  6 + 1] &= BIT4;
@@ -131,9 +131,9 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       {
         case  8: {
                    std::size_t maxLoopDist = sievingPrime * 28 + 10;
-                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
 
-                   for (; i < loopEnd; i += sievingPrime * 30 + 11)
+                   for (; i < limit; i += sievingPrime * 30 + 11)
                    {
                      sieve[i + sievingPrime *  0 +  0] &= BIT1;
                      sieve[i + sievingPrime *  6 +  2] &= BIT3;
@@ -160,9 +160,9 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       {
         case 16: {
                    std::size_t maxLoopDist = sievingPrime * 28 + 12;
-                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
 
-                   for (; i < loopEnd; i += sievingPrime * 30 + 13)
+                   for (; i < limit; i += sievingPrime * 30 + 13)
                    {
                      sieve[i + sievingPrime *  0 +  0] &= BIT2;
                      sieve[i + sievingPrime *  6 +  2] &= BIT7;
@@ -189,9 +189,9 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       {
         case 24: {
                    std::size_t maxLoopDist = sievingPrime * 28 + 16;
-                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
 
-                   for (; i < loopEnd; i += sievingPrime * 30 + 17)
+                   for (; i < limit; i += sievingPrime * 30 + 17)
                    {
                      sieve[i + sievingPrime *  0 +  0] &= BIT3;
                      sieve[i + sievingPrime *  6 +  3] &= BIT6;
@@ -218,9 +218,9 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       {
         case 32: {
                    std::size_t maxLoopDist = sievingPrime * 28 + 18;
-                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
 
-                   for (; i < loopEnd; i += sievingPrime * 30 + 19)
+                   for (; i < limit; i += sievingPrime * 30 + 19)
                    {
                      sieve[i + sievingPrime *  0 +  0] &= BIT4;
                      sieve[i + sievingPrime *  6 +  4] &= BIT2;
@@ -247,9 +247,9 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       {
         case 40: {
                    std::size_t maxLoopDist = sievingPrime * 28 + 22;
-                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
 
-                   for (; i < loopEnd; i += sievingPrime * 30 + 23)
+                   for (; i < limit; i += sievingPrime * 30 + 23)
                    {
                      sieve[i + sievingPrime *  0 +  0] &= BIT5;
                      sieve[i + sievingPrime *  6 +  5] &= BIT1;
@@ -276,9 +276,9 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       {
         case 48: {
                    std::size_t maxLoopDist = sievingPrime * 28 + 27;
-                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
 
-                   for (; i < loopEnd; i += sievingPrime * 30 + 29)
+                   for (; i < limit; i += sievingPrime * 30 + 29)
                    {
                      sieve[i + sievingPrime *  0 +  0] &= BIT6;
                      sieve[i + sievingPrime *  6 +  6] &= BIT5;
@@ -305,9 +305,9 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       {
         case 56: {
                    std::size_t maxLoopDist = sievingPrime * 28 + 1;
-                   std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
 
-                   for (; i < loopEnd; i += sievingPrime * 30 + 1)
+                   for (; i < limit; i += sievingPrime * 30 + 1)
                    {
                      sieve[i + sievingPrime *  0 + 0] &= BIT7;
                      sieve[i + sievingPrime *  6 + 1] &= BIT0;

--- a/src/EratSmall.cpp
+++ b/src/EratSmall.cpp
@@ -99,8 +99,8 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       for (;;)
       {
         case 0: {
-                  std::size_t maxLoopDist = sievingPrime * 28 + 6;
-                  std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                  std::size_t maxOffset = sievingPrime * 28 + 6;
+                  std::size_t limit = std::max(sieveSize, maxOffset) - maxOffset;
 
                   // Each iteration removes the next 8
                   // multiples of the sievingPrime.
@@ -130,8 +130,8 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       for (;;)
       {
         case  8: {
-                   std::size_t maxLoopDist = sievingPrime * 28 + 10;
-                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t maxOffset = sievingPrime * 28 + 10;
+                   std::size_t limit = std::max(sieveSize, maxOffset) - maxOffset;
 
                    for (; i < limit; i += sievingPrime * 30 + 11)
                    {
@@ -159,8 +159,8 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       for (;;)
       {
         case 16: {
-                   std::size_t maxLoopDist = sievingPrime * 28 + 12;
-                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t maxOffset = sievingPrime * 28 + 12;
+                   std::size_t limit = std::max(sieveSize, maxOffset) - maxOffset;
 
                    for (; i < limit; i += sievingPrime * 30 + 13)
                    {
@@ -188,8 +188,8 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       for (;;)
       {
         case 24: {
-                   std::size_t maxLoopDist = sievingPrime * 28 + 16;
-                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t maxOffset = sievingPrime * 28 + 16;
+                   std::size_t limit = std::max(sieveSize, maxOffset) - maxOffset;
 
                    for (; i < limit; i += sievingPrime * 30 + 17)
                    {
@@ -217,8 +217,8 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       for (;;)
       {
         case 32: {
-                   std::size_t maxLoopDist = sievingPrime * 28 + 18;
-                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t maxOffset = sievingPrime * 28 + 18;
+                   std::size_t limit = std::max(sieveSize, maxOffset) - maxOffset;
 
                    for (; i < limit; i += sievingPrime * 30 + 19)
                    {
@@ -246,8 +246,8 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       for (;;)
       {
         case 40: {
-                   std::size_t maxLoopDist = sievingPrime * 28 + 22;
-                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t maxOffset = sievingPrime * 28 + 22;
+                   std::size_t limit = std::max(sieveSize, maxOffset) - maxOffset;
 
                    for (; i < limit; i += sievingPrime * 30 + 23)
                    {
@@ -275,8 +275,8 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       for (;;)
       {
         case 48: {
-                   std::size_t maxLoopDist = sievingPrime * 28 + 27;
-                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t maxOffset = sievingPrime * 28 + 27;
+                   std::size_t limit = std::max(sieveSize, maxOffset) - maxOffset;
 
                    for (; i < limit; i += sievingPrime * 30 + 29)
                    {
@@ -304,8 +304,8 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
       for (;;)
       {
         case 56: {
-                   std::size_t maxLoopDist = sievingPrime * 28 + 1;
-                   std::size_t limit = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+                   std::size_t maxOffset = sievingPrime * 28 + 1;
+                   std::size_t limit = std::max(sieveSize, maxOffset) - maxOffset;
 
                    for (; i < limit; i += sievingPrime * 30 + 1)
                    {

--- a/src/EratSmall.cpp
+++ b/src/EratSmall.cpp
@@ -81,16 +81,16 @@ void EratSmall::crossOff(uint8_t* sieve, std::size_t sieveSize)
 {
   for (auto& prime : primes_)
   {
-    uint64_t sievingPrime = prime.getSievingPrime();
-    uint64_t i = prime.getMultipleIndex();
-    uint64_t wheelIndex = prime.getWheelIndex();
-    uint64_t maxLoopDist = sievingPrime * 28 + 27;
-    uint64_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
+    std::size_t sievingPrime = prime.getSievingPrime();
+    std::size_t i = prime.getMultipleIndex();
+    std::size_t wheelIndex = prime.getWheelIndex();
+    std::size_t maxLoopDist = sievingPrime * 28 + 27;
+    std::size_t loopEnd = std::max(sieveSize, maxLoopDist) - maxLoopDist;
 
     #define CHECK_FINISHED(wheelIndex) \
       if_unlikely(i >= sieveSize) \
       { \
-        uint64_t multipleIndex = i - sieveSize; \
+        std::size_t multipleIndex = i - sieveSize; \
         prime.set(multipleIndex, wheelIndex); \
         break; \
       }


### PR DESCRIPTION
Get rid of pointer comparisons using operator `<` because that's undefined behavior in C/C++ (if one of the pointers is outside of the originally allocated array).