### PR TITLE
Fix use after free in `primesieve_iterator_clear()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4...3.22)
 project(primesieve CXX)
-set(PRIMESIEVE_VERSION "8.0")
-set(PRIMESIEVE_SOVERSION "10.0.0")
+set(PRIMESIEVE_VERSION "8.1")
+set(PRIMESIEVE_SOVERSION "10.1.0")
 
 # Build options ######################################################
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Changes in version 8.1, 10/07/2022
+==================================
+
+* iterator.cpp: Fix use after free in primesieve::iterator::clear().
+* iterator-c.cpp: Fix use after free in primesieve_iterator_clear().
+
 Changes in version 8.0, 26/06/2022
 ==================================
 

--- a/include/primesieve.h
+++ b/include/primesieve.h
@@ -15,9 +15,9 @@
 #ifndef PRIMESIEVE_H
 #define PRIMESIEVE_H
 
-#define PRIMESIEVE_VERSION "8.0"
+#define PRIMESIEVE_VERSION "8.1"
 #define PRIMESIEVE_VERSION_MAJOR 8
-#define PRIMESIEVE_VERSION_MINOR 0
+#define PRIMESIEVE_VERSION_MINOR 1
 
 #include <primesieve/iterator.h>
 

--- a/include/primesieve.hpp
+++ b/include/primesieve.hpp
@@ -13,9 +13,9 @@
 #ifndef PRIMESIEVE_HPP
 #define PRIMESIEVE_HPP
 
-#define PRIMESIEVE_VERSION "8.0"
+#define PRIMESIEVE_VERSION "8.1"
 #define PRIMESIEVE_VERSION_MAJOR 8
-#define PRIMESIEVE_VERSION_MINOR 0
+#define PRIMESIEVE_VERSION_MINOR 1
 
 #include <primesieve/iterator.hpp>
 #include <primesieve/primesieve_error.hpp>

--- a/include/primesieve/iterator.h
+++ b/include/primesieve/iterator.h
@@ -66,11 +66,11 @@ void primesieve_init(primesieve_iterator* it);
 void primesieve_free_iterator(primesieve_iterator* it);
 
 /**
-  * Reset the start number to 0 and free most memory.
-  * Keeps some smaller data structures in memory
-  * (e.g. the PreSieve object) that are useful if the
-  * primesieve::iterator is reused. The remaining memory
-  * uses at most 200 kilobytes.
+ * Reset the start number to 0 and free most memory.
+ * Keeps some smaller data structures in memory
+ * (e.g. the PreSieve object) that are useful if the
+ * primesieve::iterator is reused. The remaining memory
+ * uses at most 200 kilobytes.
  */
 void primesieve_clear(primesieve_iterator* it);
 

--- a/include/primesieve/iterator.h
+++ b/include/primesieve/iterator.h
@@ -66,10 +66,11 @@ void primesieve_init(primesieve_iterator* it);
 void primesieve_free_iterator(primesieve_iterator* it);
 
 /**
- * Frees most memory, but keeps some smaller data structures
- * (e.g. the PreSieve object) that are useful if the
- * primesieve_iterator is reused. The remaining memory
- * uses at most 200 kilobytes.
+  * Reset the start number to 0 and free most memory.
+  * Keeps some smaller data structures in memory
+  * (e.g. the PreSieve object) that are useful if the
+  * primesieve::iterator is reused. The remaining memory
+  * uses at most 200 kilobytes.
  */
 void primesieve_clear(primesieve_iterator* it);
 

--- a/include/primesieve/iterator.h
+++ b/include/primesieve/iterator.h
@@ -69,7 +69,7 @@ void primesieve_free_iterator(primesieve_iterator* it);
  * Reset the start number to 0 and free most memory.
  * Keeps some smaller data structures in memory
  * (e.g. the PreSieve object) that are useful if the
- * primesieve::iterator is reused. The remaining memory
+ * primesieve_iterator is reused. The remaining memory
  * uses at most 200 kilobytes.
  */
 void primesieve_clear(primesieve_iterator* it);

--- a/include/primesieve/iterator.hpp
+++ b/include/primesieve/iterator.hpp
@@ -75,7 +75,8 @@ struct iterator
   /// Frees all memory
   ~iterator();
 
-  /// Frees most memory, but keeps some smaller data structures
+  /// Reset the start number to 0 and free most memory.
+  /// Keeps some smaller data structures in memory
   /// (e.g. the PreSieve object) that are useful if the
   /// primesieve::iterator is reused. The remaining memory
   /// uses at most 200 kilobytes.

--- a/src/iterator-c.cpp
+++ b/src/iterator-c.cpp
@@ -54,13 +54,23 @@ void primesieve_skipto(primesieve_iterator* it,
   it->stop_hint = stop_hint;
   it->primes = nullptr;
 
+  // Frees most memory, but keeps some smaller data
+  // structures (e.g. the PreSieve object) that are
+  // useful if the primesieve::iterator is reused.
+  // The remaining memory uses at most 200 kilobytes.
   if (it->memory)
   {
     auto* memory = (IteratorMemory*) it->memory;
     memory->stop = start;
     memory->dist = 0;
-    primesieve_clear(it);
+    memory->deletePrimeGenerator();
+    memory->deletePrimes();
   }
+}
+
+void primesieve_clear(primesieve_iterator* it)
+{
+  primesieve_skipto(it, 0, std::numeric_limits<uint64_t>::max());
 }
 
 /// C destructor
@@ -70,21 +80,6 @@ void primesieve_free_iterator(primesieve_iterator* it)
   {
     delete (IteratorMemory*) it->memory;
     it->memory = nullptr;
-  }
-}
-
-/// Frees most memory, but keeps some smaller data structures
-/// (e.g. the PreSieve object) that are useful if the
-/// primesieve_iterator is reused. The remaining memory
-/// uses at most 200 kilobytes.
-///
-void primesieve_clear(primesieve_iterator* it)
-{
-  if (it->memory)
-  {
-    auto* memory = (IteratorMemory*) it->memory;
-    memory->deletePrimeGenerator();
-    memory->deletePrimes();
   }
 }
 

--- a/src/iterator-c.cpp
+++ b/src/iterator-c.cpp
@@ -56,7 +56,7 @@ void primesieve_skipto(primesieve_iterator* it,
 
   // Frees most memory, but keeps some smaller data
   // structures (e.g. the PreSieve object) that are
-  // useful if the primesieve::iterator is reused.
+  // useful if the primesieve_iterator is reused.
   // The remaining memory uses at most 200 kilobytes.
   if (it->memory)
   {

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -102,33 +102,28 @@ void iterator::skipto(uint64_t start,
   stop_hint_ = stop_hint;
   primes_ = nullptr;
 
+  // Frees most memory, but keeps some smaller data
+  // structures (e.g. the PreSieve object) that are
+  // useful if the primesieve::iterator is reused.
+  // The remaining memory uses at most 200 kilobytes.
   if (memory_)
   {
     auto* memory = (IteratorMemory*) memory_;
     memory->stop = start;
     memory->dist = 0;
-    clear();
+    memory->deletePrimeGenerator();
+    memory->deletePrimes();
   }
+}
+
+void iterator::clear() noexcept
+{
+  skipto(0);
 }
 
 iterator::~iterator()
 {
   freeAllMemory(this);
-}
-
-/// Frees most memory, but keeps some smaller data structures
-/// (e.g. the PreSieve object) that are useful if the
-/// primesieve::iterator is reused. The remaining memory
-/// uses at most 200 kilobytes.
-///
-void iterator::clear() noexcept
-{
-  if (memory_)
-  {
-    auto* memory = (IteratorMemory*) memory_;
-    memory->deletePrimeGenerator();
-    memory->deletePrimes();
-  }
 }
 
 void iterator::generate_next_primes()

--- a/test/clear_primesieve_iterator1.cpp
+++ b/test/clear_primesieve_iterator1.cpp
@@ -1,0 +1,46 @@
+///
+/// @file   clear_primesieve_iterator1.cpp
+/// @brief  Test next_prime() of primesieve::iterator.
+///
+/// Copyright (C) 2022 Kim Walisch, <kim.walisch@gmail.com>
+///
+/// This file is distributed under the BSD License. See the COPYING
+/// file in the top level directory.
+///
+
+#include <primesieve.hpp>
+
+#include <stdint.h>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <vector>
+
+void check(bool OK)
+{
+  std::cout << "   " << (OK ? "OK" : "ERROR") << "\n";
+  if (!OK)
+    std::exit(1);
+}
+
+int main()
+{
+  primesieve::iterator it;
+  uint64_t primes = 0;
+
+  for (int i = 0; i < 10; i++)
+  {
+    it.clear();
+    uint64_t prime = it.next_prime();
+    for (; prime < 100000; prime = it.next_prime())
+      primes++;
+  }
+
+  std::cout << "Count of the primes = " << primes;
+  check(primes == 9592 * 10);
+
+  std::cout << std::endl;
+  std::cout << "All tests passed successfully!" << std::endl;
+
+  return 0;
+}

--- a/test/clear_primesieve_iterator2.c
+++ b/test/clear_primesieve_iterator2.c
@@ -1,0 +1,51 @@
+///
+/// @file   clear_primesieve_iterator2.c
+/// @brief  Test next_prime() of primesieve::iterator.
+///
+/// Copyright (C) 2022 Kim Walisch, <kim.walisch@gmail.com>
+///
+/// This file is distributed under the BSD License. See the COPYING
+/// file in the top level directory.
+///
+
+#include <primesieve.h>
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void check(int OK)
+{
+  if (OK)
+    printf("   OK\n");
+  else
+  {
+    printf("   ERROR\n");
+    exit(1);
+  }
+}
+
+int main()
+{
+  primesieve_iterator it;
+  primesieve_init(&it);
+  uint64_t primes = 0;
+
+  for (int i = 0; i < 10; i++)
+  {
+    primesieve_clear(&it);
+    uint64_t prime = primesieve_next_prime(&it);
+    for (; prime < 100000; prime = primesieve_next_prime(&it))
+      primes++;
+  }
+
+  printf("Count of the primes = %" PRIu64, primes);
+  check(primes == 9592 * 10);
+
+  primesieve_free_iterator(&it);
+  printf("\n");
+  printf("All tests passed successfully!\n");
+
+  return 0;
+}


### PR DESCRIPTION
`primesieve_iterator_clear()` was introduced in primesieve-8.0, it is not yet being internally in both primesieve and primecount. Hence this is a non critical bug. In `primesieve_iterator_clear()` the `i` & `size` variables were not reset to 0.