### PR TITLE
CMake: fix undefined reference to pthread_create

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,8 @@ if(BUILD_PRIMESIEVE)
     if(TARGET libprimesieve-static)
         add_dependencies(primesieve libprimesieve-static)
     endif()
+
+    target_link_libraries(primesieve Threads::Threads)
 endif()
 
 # Install headers ####################################################


### PR DESCRIPTION
on conda-forge/linux I got this kind of error with 12.0 (ok in 11.x):
```
-- The CXX compiler identification is GNU 9.3.1
-- Check for working CXX compiler: /opt/rh/devtoolset-9/root/usr/bin/c++
-- Check for working CXX compiler: /opt/rh/devtoolset-9/root/usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test atomic64
-- Performing Test atomic64 - Success
-- Performing Test ftree_vectorize
-- Performing Test ftree_vectorize - Success
-- Performing Test fvect_cost_model
-- Performing Test fvect_cost_model - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /usr/local/src/primesieve-12.0
Scanning dependencies of target libprimesieve
[  3%] Building CXX object CMakeFiles/libprimesieve.dir/src/api-c.cpp.o
[  7%] Building CXX object CMakeFiles/libprimesieve.dir/src/api.cpp.o
[ 14%] Building CXX object CMakeFiles/libprimesieve.dir/src/EratMedium.cpp.o
[ 14%] Building CXX object CMakeFiles/libprimesieve.dir/src/CountPrintPrimes.cpp.o
[ 28%] Building CXX object CMakeFiles/libprimesieve.dir/src/EratBig.cpp.o
[ 28%] Building CXX object CMakeFiles/libprimesieve.dir/src/Erat.cpp.o
[ 28%] Building CXX object CMakeFiles/libprimesieve.dir/src/CpuInfo.cpp.o
[ 28%] Building CXX object CMakeFiles/libprimesieve.dir/src/EratSmall.cpp.o
[ 32%] Building CXX object CMakeFiles/libprimesieve.dir/src/iterator-c.cpp.o
[ 35%] Building CXX object CMakeFiles/libprimesieve.dir/src/iterator.cpp.o
[ 39%] Building CXX object CMakeFiles/libprimesieve.dir/src/IteratorHelper.cpp.o
[ 42%] Building CXX object CMakeFiles/libprimesieve.dir/src/LookupTables.cpp.o
[ 46%] Building CXX object CMakeFiles/libprimesieve.dir/src/MemoryPool.cpp.o
[ 50%] Building CXX object CMakeFiles/libprimesieve.dir/src/PrimeGenerator.cpp.o
[ 53%] Building CXX object CMakeFiles/libprimesieve.dir/src/nthPrime.cpp.o
[ 57%] Building CXX object CMakeFiles/libprimesieve.dir/src/ParallelSieve.cpp.o
[ 60%] Building CXX object CMakeFiles/libprimesieve.dir/src/popcount.cpp.o
[ 64%] Building CXX object CMakeFiles/libprimesieve.dir/src/PreSieve.cpp.o
[ 67%] Building CXX object CMakeFiles/libprimesieve.dir/src/PrimeSieve.cpp.o
[ 71%] Building CXX object CMakeFiles/libprimesieve.dir/src/RiemannR.cpp.o
[ 75%] Building CXX object CMakeFiles/libprimesieve.dir/src/SievingPrimes.cpp.o
[ 78%] Linking CXX shared library libprimesieve.so
[ 78%] Built target libprimesieve
Scanning dependencies of target primesieve
[ 82%] Building CXX object CMakeFiles/primesieve.dir/src/app/help.cpp.o
[ 85%] Building CXX object CMakeFiles/primesieve.dir/src/app/main.cpp.o
[ 89%] Building CXX object CMakeFiles/primesieve.dir/src/app/CmdOptions.cpp.o
[ 96%] Building CXX object CMakeFiles/primesieve.dir/src/app/test.cpp.o
[ 96%] Building CXX object CMakeFiles/primesieve.dir/src/app/stressTest.cpp.o
[100%] Linking CXX executable primesieve
/opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: CMakeFiles/primesieve.dir/src/app/stressTest.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: /lib64/libpthread.so.0: error adding symbols: DSO missing from command line
```
this might be due to primesieve exe using std::threads